### PR TITLE
Fixed issue with format of module download response, use git url for downloads

### DIFF
--- a/lambda/internal/modules/versions.go
+++ b/lambda/internal/modules/versions.go
@@ -37,14 +37,10 @@ func GetVersions(ctx context.Context, ghClient *githubv4.Client, namespace strin
 	return versions, nil
 }
 
-func GetVersionDownloadUrl(ctx context.Context, ghClient *githubv4.Client, namespace string, name string, system string, version string) (*string, error) {
+func GetVersionDownloadUrl(_ context.Context, namespace string, name string, system string, version string) string {
 	// the repo name should match the format `terraform-<system>-<name>`
 	repoName := fmt.Sprintf("terraform-%s-%s", system, name)
 
-	release, err := github.FindRelease(ctx, ghClient, namespace, repoName, version)
-	if err != nil {
-		return nil, err
-	}
-
-	return &release.TagCommit.TarballUrl, nil
+	// nothing fancy, just return the url for the release
+	return fmt.Sprintf("git::https://github.com/%s/%s?ref=v%s", namespace, repoName, version)
 }

--- a/lambda/moduleDownload.go
+++ b/lambda/moduleDownload.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	"fmt"
 	"github.com/aws/aws-lambda-go/events"
 	"github.com/opentffoundation/registry/internal/modules"
 )
@@ -18,15 +17,12 @@ func downloadModuleVersion(config Config) LambdaFunc {
 	return func(ctx context.Context, req events.APIGatewayProxyRequest) (events.APIGatewayProxyResponse, error) {
 		params := getDownloadModuleHandlerPathParams(req)
 
-		url, err := modules.GetVersionDownloadUrl(ctx, config.RawGithubv4Client, params.Namespace, params.Name, params.System, params.Version)
-		if err != nil {
-			// log the error too for dev
-			fmt.Printf("error fetching version: %s\n", err)
-			return events.APIGatewayProxyResponse{StatusCode: 500}, err
-		}
+		url := modules.GetVersionDownloadUrl(ctx, params.Namespace, params.Name, params.System, params.Version)
+
+		// TODO : check that the repo does exist
 
 		return events.APIGatewayProxyResponse{StatusCode: 200, Body: "", Headers: map[string]string{
-			"X-Terraform-Get": *url,
+			"X-Terraform-Get": url,
 		}}, nil
 	}
 }

--- a/lambda/moduleVersions.go
+++ b/lambda/moduleVersions.go
@@ -25,6 +25,10 @@ func getListModuleVersionsPathParams(req events.APIGatewayProxyRequest) ListModu
 }
 
 type ListModuleVersionsResponse struct {
+	Modules []ModulesResponse `json:"modules"`
+}
+
+type ModulesResponse struct {
 	Versions []modules.Version `json:"versions"`
 }
 
@@ -39,7 +43,11 @@ func listModuleVersions(config Config) LambdaFunc {
 		}
 
 		response := ListModuleVersionsResponse{
-			Versions: versions,
+			Modules: []ModulesResponse{
+				{
+					Versions: versions,
+				},
+			},
 		}
 
 		resBody, err := json.Marshal(response)


### PR DESCRIPTION
The format of the response was missing a wrapping "modules" property.

Also this switches to using the git cloning format of a url that is described here: https://github.com/opentffoundation/opentf/blob/0941afc75a6be1eec3819d501e015389043ea38d/website/docs/language/modules/sources.mdx#L190-L191