### PR TITLE
move to using a resource for the r53_zone instead of datasource

### DIFF
--- a/lambda.tf
+++ b/lambda.tf
@@ -53,9 +53,3 @@ resource "aws_cloudwatch_log_group" "log_group" {
   name              = "/aws/lambda/${aws_lambda_function.function.function_name}"
   retention_in_days = 7
 }
-
-output "function_name" {
-  description = "Name of the Lambda function."
-
-  value = aws_lambda_function.function.function_name
-}

--- a/r53.tf
+++ b/r53.tf
@@ -5,9 +5,8 @@ resource "aws_acm_certificate" "api" {
   validation_method = "DNS"
 }
 
-data "aws_route53_zone" "public" {
+resource "aws_route53_zone" "public" {
   name         = var.route53_zone_name
-  private_zone = false
 }
 
 resource "aws_route53_record" "api_validation" {
@@ -24,7 +23,7 @@ resource "aws_route53_record" "api_validation" {
   records         = [each.value.record]
   ttl             = 60
   type            = each.value.type
-  zone_id         = data.aws_route53_zone.public.zone_id
+  zone_id         = aws_route53_zone.public.zone_id
 }
 
 resource "aws_acm_certificate_validation" "api" {
@@ -37,11 +36,16 @@ resource "aws_acm_certificate_validation" "api" {
 resource "aws_route53_record" "api" {
   name    = aws_api_gateway_domain_name.domain.domain_name
   type    = "A"
-  zone_id = data.aws_route53_zone.public.zone_id
+  zone_id = aws_route53_zone.public.zone_id
 
   alias {
     name                   = aws_api_gateway_domain_name.domain.cloudfront_domain_name
     zone_id                = aws_api_gateway_domain_name.domain.cloudfront_zone_id
     evaluate_target_health = false
   }
+}
+
+output "nameservers" {
+  value = aws_route53_zone.public.name_servers
+  description = "The name servers for the hosted zone."
 }


### PR DESCRIPTION
fixes #9 

This resolves the issue of engineers requiring r53 to be configured BEFORE deployment. 
Now engineers can set up their dns servers after deployment.