### PR TITLE
feat: Improve Terraform registry GitHub integration

### DIFF
--- a/lambda/internal/github/github.go
+++ b/lambda/internal/github/github.go
@@ -3,6 +3,7 @@ package github
 import (
 	"context"
 	"fmt"
+	"github.com/google/go-github/v54/github"
 	"github.com/shurcooL/githubv4"
 	"io"
 	"net/http"
@@ -46,6 +47,17 @@ type ReleaseAsset struct {
 	ID          string // The ID of the asset.
 	DownloadURL string // The URL to download the asset.
 	Name        string // The name of the asset.
+}
+
+func RepositoryExists(ctx context.Context, managedGhClient *github.Client, namespace, name string) (bool, error) {
+	_, response, err := managedGhClient.Repositories.Get(ctx, namespace, name)
+	if err != nil {
+		if response.StatusCode == http.StatusNotFound {
+			return false, nil
+		}
+		return false, fmt.Errorf("failed to get repository: %v", err)
+	}
+	return true, nil
 }
 
 func FindRelease(ctx context.Context, ghClient *githubv4.Client, namespace, name, versionNumber string) (*GHRelease, error) {

--- a/lambda/internal/modules/repo.go
+++ b/lambda/internal/modules/repo.go
@@ -1,0 +1,9 @@
+package modules
+
+import "fmt"
+
+// GetRepoName returns the repo name for a module
+// The repo name should match the format `terraform-<system>-<name>`
+func GetRepoName(system, name string) string {
+	return fmt.Sprintf("terraform-%s-%s", system, name)
+}

--- a/lambda/internal/modules/versions.go
+++ b/lambda/internal/modules/versions.go
@@ -2,7 +2,6 @@ package modules
 
 import (
 	"context"
-	"fmt"
 	"github.com/opentffoundation/registry/internal/github"
 	"github.com/shurcooL/githubv4"
 
@@ -10,11 +9,8 @@ import (
 )
 
 // TODO: doc
-func GetVersions(ctx context.Context, ghClient *githubv4.Client, namespace string, name string, system string) ([]Version, error) {
-	// the repo name should match the format `terraform-<system>-<name>`
-	repoName := fmt.Sprintf("terraform-%s-%s", system, name)
-
-	releases, err := github.FetchReleases(ctx, ghClient, namespace, repoName)
+func GetVersions(ctx context.Context, ghClient *githubv4.Client, namespace string, name string) ([]Version, error) {
+	releases, err := github.FetchReleases(ctx, ghClient, namespace, name)
 	if err != nil {
 		return nil, err
 	}
@@ -35,12 +31,4 @@ func GetVersions(ctx context.Context, ghClient *githubv4.Client, namespace strin
 		versions = append(versions, version)
 	}
 	return versions, nil
-}
-
-func GetVersionDownloadUrl(_ context.Context, namespace string, name string, system string, version string) string {
-	// the repo name should match the format `terraform-<system>-<name>`
-	repoName := fmt.Sprintf("terraform-%s-%s", system, name)
-
-	// nothing fancy, just return the url for the release
-	return fmt.Sprintf("git::https://github.com/%s/%s?ref=v%s", namespace, repoName, version)
 }

--- a/lambda/internal/providers/repo.go
+++ b/lambda/internal/providers/repo.go
@@ -1,0 +1,9 @@
+package providers
+
+import "fmt"
+
+// GetRepoName returns the repo name for a provider
+// The repo name should match the format `terraform-provider-<name>`
+func GetRepoName(name string) string {
+	return fmt.Sprintf("terraform-provider-%s", name)
+}

--- a/lambda/internal/providers/versions.go
+++ b/lambda/internal/providers/versions.go
@@ -19,10 +19,7 @@ import (
 //
 // Returns a slice of Version structures detailing each available version. If an error occurs during fetching or processing, it returns an error.
 func GetVersions(ctx context.Context, ghClient *githubv4.Client, namespace string, name string) ([]Version, error) {
-	// the repo name should match the format `terraform-provider-<name>`
-	repoName := fmt.Sprintf("terraform-provider-%s", name)
-
-	releases, err := github.FetchReleases(ctx, ghClient, namespace, repoName)
+	releases, err := github.FetchReleases(ctx, ghClient, namespace, name)
 	if err != nil {
 		return nil, err
 	}
@@ -80,11 +77,8 @@ func GetVersions(ctx context.Context, ghClient *githubv4.Client, namespace strin
 // Returns a VersionDetails structure with detailed information about the specified version. If an error occurs during fetching or processing, it returns an error.
 
 func GetVersion(ctx context.Context, ghClient *githubv4.Client, namespace string, name string, version string, OS string, arch string) (*VersionDetails, error) {
-	// Construct the repo name.
-	repoName := fmt.Sprintf("terraform-provider-%s", name)
-
 	// Fetch the specific release for the given version.
-	release, err := github.FindRelease(ctx, ghClient, namespace, repoName, version)
+	release, err := github.FindRelease(ctx, ghClient, namespace, name, version)
 	if err != nil {
 		return nil, err
 	}

--- a/lambda/moduleDownload.go
+++ b/lambda/moduleDownload.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"github.com/aws/aws-lambda-go/events"
 	"github.com/opentffoundation/registry/internal/github"
+	"github.com/opentffoundation/registry/internal/modules"
 )
 
 type DownloadModuleHandlerPathParams struct {
@@ -17,9 +18,8 @@ type DownloadModuleHandlerPathParams struct {
 func downloadModuleVersion(config Config) LambdaFunc {
 	return func(ctx context.Context, req events.APIGatewayProxyRequest) (events.APIGatewayProxyResponse, error) {
 		params := getDownloadModuleHandlerPathParams(req)
-
-		// the repo name should match the format `terraform-<system>-<name>`
-		repoName := fmt.Sprintf("terraform-%s-%s", params.System, params.Name)
+		
+		repoName := modules.GetRepoName(params.System, params.Name)
 
 		// check if the repo exists
 		exists, err := github.RepositoryExists(ctx, config.ManagedGithubClient, params.Namespace, repoName)

--- a/lambda/moduleVersions.go
+++ b/lambda/moduleVersions.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"encoding/json"
-	"fmt"
 	"github.com/aws/aws-lambda-go/events"
 	"github.com/opentffoundation/registry/internal/github"
 	"github.com/opentffoundation/registry/internal/modules"
@@ -38,8 +37,7 @@ func listModuleVersions(config Config) LambdaFunc {
 	return func(ctx context.Context, req events.APIGatewayProxyRequest) (events.APIGatewayProxyResponse, error) {
 		params := getListModuleVersionsPathParams(req)
 
-		// the repo name should match the format `terraform-<system>-<name>`
-		repoName := fmt.Sprintf("terraform-%s-%s", params.System, params.Name)
+		repoName := modules.GetRepoName(params.System, params.Name)
 
 		// check the repo exists
 		exists, err := github.RepositoryExists(ctx, config.ManagedGithubClient, params.Namespace, repoName)

--- a/lambda/providerDownload.go
+++ b/lambda/providerDownload.go
@@ -22,7 +22,7 @@ func downloadProviderVersion(config Config) LambdaFunc {
 		params := getDownloadPathParams(req)
 
 		// Construct the repo name.
-		repoName := fmt.Sprintf("terraform-provider-%s", params.Type)
+		repoName := providers.GetRepoName(params.Type)
 
 		// check the repo exists
 		exists, err := github.RepositoryExists(ctx, config.ManagedGithubClient, params.Namespace, repoName)

--- a/lambda/providerDownload.go
+++ b/lambda/providerDownload.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"github.com/aws/aws-lambda-go/events"
+	"github.com/opentffoundation/registry/internal/github"
 	"github.com/opentffoundation/registry/internal/providers"
 )
 
@@ -19,6 +20,18 @@ type DownloadHandlerPathParams struct {
 func downloadProviderVersion(config Config) LambdaFunc {
 	return func(ctx context.Context, req events.APIGatewayProxyRequest) (events.APIGatewayProxyResponse, error) {
 		params := getDownloadPathParams(req)
+
+		// Construct the repo name.
+		repoName := fmt.Sprintf("terraform-provider-%s", params.Type)
+
+		// check the repo exists
+		exists, err := github.RepositoryExists(ctx, config.ManagedGithubClient, params.Namespace, repoName)
+		if err != nil {
+			return events.APIGatewayProxyResponse{StatusCode: 500}, err
+		}
+		if !exists {
+			return NotFoundResponse, nil
+		}
 
 		versionDownloadResponse, err := providers.GetVersion(ctx, config.RawGithubv4Client, params.Namespace, params.Type, params.Version, params.OS, params.Architecture)
 		if err != nil {

--- a/lambda/providerVersions.go
+++ b/lambda/providerVersions.go
@@ -3,7 +3,9 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"github.com/aws/aws-lambda-go/events"
+	"github.com/opentffoundation/registry/internal/github"
 	"github.com/opentffoundation/registry/internal/providers"
 )
 
@@ -27,7 +29,19 @@ func listProviderVersions(config Config) LambdaFunc {
 	return func(ctx context.Context, req events.APIGatewayProxyRequest) (events.APIGatewayProxyResponse, error) {
 		params := getListProvidersPathParams(req)
 
-		versions, err := providers.GetVersions(ctx, config.RawGithubv4Client, params.Namespace, params.Type)
+		// Construct the repo name.
+		repoName := fmt.Sprintf("terraform-provider-%s", params.Type)
+
+		// check the repo exists
+		exists, err := github.RepositoryExists(ctx, config.ManagedGithubClient, params.Namespace, repoName)
+		if err != nil {
+			return events.APIGatewayProxyResponse{StatusCode: 500}, err
+		}
+		if !exists {
+			return NotFoundResponse, nil
+		}
+
+		versions, err := providers.GetVersions(ctx, config.RawGithubv4Client, params.Namespace, repoName)
 		if err != nil {
 			return events.APIGatewayProxyResponse{StatusCode: 500}, err
 		}

--- a/lambda/providerVersions.go
+++ b/lambda/providerVersions.go
@@ -3,7 +3,6 @@ package main
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"github.com/aws/aws-lambda-go/events"
 	"github.com/opentffoundation/registry/internal/github"
 	"github.com/opentffoundation/registry/internal/providers"
@@ -30,7 +29,7 @@ func listProviderVersions(config Config) LambdaFunc {
 		params := getListProvidersPathParams(req)
 
 		// Construct the repo name.
-		repoName := fmt.Sprintf("terraform-provider-%s", params.Type)
+		repoName := providers.GetRepoName(params.Type)
 
 		// check the repo exists
 		exists, err := github.RepositoryExists(ctx, config.ManagedGithubClient, params.Namespace, repoName)

--- a/lambda/responses.go
+++ b/lambda/responses.go
@@ -1,0 +1,5 @@
+package main
+
+import "github.com/aws/aws-lambda-go/events"
+
+var NotFoundResponse = events.APIGatewayProxyResponse{StatusCode: 404, Body: `{"errors":["not found"]}`}


### PR DESCRIPTION
Fixes #5 

- Add function to check if a GitHub repository exists using `go-github`.
- Refactor functions to use constructed repo names for querying releases.
- Implement repo existence check in Lambda functions before processing.
- Simplify repo name construction by removing unnecessary string formatting.
- Add a centralized 404 Not Found response for easier error handling.