### PR TITLE
Support redirects between GH namespaces

### DIFF
--- a/lambda/main.go
+++ b/lambda/main.go
@@ -28,9 +28,9 @@ func main() {
 		panic("GITHUB_TOKEN_SECRET_ASM_NAME environment variable not set")
 	}
 
-	redirects := make(map[string]string)
+	providerRedirects := make(map[string]string)
 	if redirectsJSON, ok := os.LookupEnv("PROVIDER_NAMESPACE_REDIRECTS"); ok {
-		if err := json.Unmarshal([]byte(redirectsJSON), &redirects); err != nil {
+		if err := json.Unmarshal([]byte(redirectsJSON), &providerRedirects); err != nil {
 			panic(fmt.Errorf("could not parse PROVIDER_NAMESPACE_REDIRECTS: %w", err))
 		}
 	}
@@ -42,7 +42,7 @@ func main() {
 		panic(err)
 	}
 
-	config.Redirects = redirects
+	config.ProviderRedirects = providerRedirects
 	lambda.Start(Router(*config))
 }
 

--- a/lambda/main.go
+++ b/lambda/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"os"
@@ -27,6 +28,13 @@ func main() {
 		panic("GITHUB_TOKEN_SECRET_ASM_NAME environment variable not set")
 	}
 
+	redirects := make(map[string]string)
+	if redirectsJSON, ok := os.LookupEnv("PROVIDER_NAMESPACE_REDIRECTS"); ok {
+		if err := json.Unmarshal([]byte(redirectsJSON), &redirects); err != nil {
+			panic(fmt.Errorf("could not parse PROVIDER_NAMESPACE_REDIRECTS: %w", err))
+		}
+	}
+
 	ctx := context.Background()
 
 	config, err := buildConfig(ctx, githubTokenSecretName)
@@ -34,6 +42,7 @@ func main() {
 		panic(err)
 	}
 
+	config.Redirects = redirects
 	lambda.Start(Router(*config))
 }
 

--- a/lambda/moduleDownload.go
+++ b/lambda/moduleDownload.go
@@ -3,7 +3,9 @@ package main
 import (
 	"context"
 	"fmt"
+
 	"github.com/aws/aws-lambda-go/events"
+
 	"github.com/opentffoundation/registry/internal/github"
 	"github.com/opentffoundation/registry/internal/modules"
 )
@@ -18,7 +20,7 @@ type DownloadModuleHandlerPathParams struct {
 func downloadModuleVersion(config Config) LambdaFunc {
 	return func(ctx context.Context, req events.APIGatewayProxyRequest) (events.APIGatewayProxyResponse, error) {
 		params := getDownloadModuleHandlerPathParams(req)
-		
+
 		repoName := modules.GetRepoName(params.System, params.Name)
 
 		// check if the repo exists

--- a/lambda/moduleVersions.go
+++ b/lambda/moduleVersions.go
@@ -1,14 +1,13 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
+
 	"github.com/aws/aws-lambda-go/events"
+
 	"github.com/opentffoundation/registry/internal/github"
 	"github.com/opentffoundation/registry/internal/modules"
-)
-
-import (
-	"context"
 )
 
 type ListModuleVersionsPathParams struct {
@@ -36,7 +35,6 @@ type ModulesResponse struct {
 func listModuleVersions(config Config) LambdaFunc {
 	return func(ctx context.Context, req events.APIGatewayProxyRequest) (events.APIGatewayProxyResponse, error) {
 		params := getListModuleVersionsPathParams(req)
-
 		repoName := modules.GetRepoName(params.System, params.Name)
 
 		// check the repo exists

--- a/lambda/providerDownload.go
+++ b/lambda/providerDownload.go
@@ -22,7 +22,7 @@ type DownloadHandlerPathParams struct {
 func downloadProviderVersion(config Config) LambdaFunc {
 	return func(ctx context.Context, req events.APIGatewayProxyRequest) (events.APIGatewayProxyResponse, error) {
 		params := getDownloadPathParams(req)
-		effectiveNamespace := config.EffectiveNamespace(params.Namespace)
+		effectiveNamespace := config.EffectiveProviderNamespace(params.Namespace)
 
 		// Construct the repo name.
 		repoName := providers.GetRepoName(params.Type)

--- a/lambda/providerDownload.go
+++ b/lambda/providerDownload.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+
 	"github.com/aws/aws-lambda-go/events"
+
 	"github.com/opentffoundation/registry/internal/github"
 	"github.com/opentffoundation/registry/internal/providers"
 )
@@ -20,12 +22,13 @@ type DownloadHandlerPathParams struct {
 func downloadProviderVersion(config Config) LambdaFunc {
 	return func(ctx context.Context, req events.APIGatewayProxyRequest) (events.APIGatewayProxyResponse, error) {
 		params := getDownloadPathParams(req)
+		effectiveNamespace := config.EffectiveNamespace(params.Namespace)
 
 		// Construct the repo name.
 		repoName := providers.GetRepoName(params.Type)
 
 		// check the repo exists
-		exists, err := github.RepositoryExists(ctx, config.ManagedGithubClient, params.Namespace, repoName)
+		exists, err := github.RepositoryExists(ctx, config.ManagedGithubClient, effectiveNamespace, repoName)
 		if err != nil {
 			return events.APIGatewayProxyResponse{StatusCode: 500}, err
 		}
@@ -33,7 +36,7 @@ func downloadProviderVersion(config Config) LambdaFunc {
 			return NotFoundResponse, nil
 		}
 
-		versionDownloadResponse, err := providers.GetVersion(ctx, config.RawGithubv4Client, params.Namespace, params.Type, params.Version, params.OS, params.Architecture)
+		versionDownloadResponse, err := providers.GetVersion(ctx, config.RawGithubv4Client, effectiveNamespace, params.Type, params.Version, params.OS, params.Architecture)
 		if err != nil {
 			// log the error too for dev
 			fmt.Printf("error fetching version: %s\n", err)

--- a/lambda/providerVersions.go
+++ b/lambda/providerVersions.go
@@ -29,7 +29,7 @@ type ListProviderVersionsResponse struct {
 func listProviderVersions(config Config) LambdaFunc {
 	return func(ctx context.Context, req events.APIGatewayProxyRequest) (events.APIGatewayProxyResponse, error) {
 		params := getListProvidersPathParams(req)
-		effectiveNamespace := config.EffectiveNamespace(params.Namespace)
+		effectiveNamespace := config.EffectiveProviderNamespace(params.Namespace)
 
 		// Construct the repo name.
 		repoName := providers.GetRepoName(params.Type)

--- a/lambda/router.go
+++ b/lambda/router.go
@@ -13,11 +13,14 @@ import (
 type Config struct {
 	ManagedGithubClient *github.Client
 	RawGithubv4Client   *githubv4.Client
-	Redirects           map[string]string
+	ProviderRedirects   map[string]string
 }
 
-func (c Config) EffectiveNamespace(namespace string) string {
-	if redirect, ok := c.Redirects[namespace]; ok {
+// EffectiveProviderNamespace will map namespaces for providers in situations
+// where the author (owner of the namespace) does not release artifacts as
+// GitHub Releases.
+func (c Config) EffectiveProviderNamespace(namespace string) string {
+	if redirect, ok := c.ProviderRedirects[namespace]; ok {
 		return redirect
 	}
 

--- a/lambda/router.go
+++ b/lambda/router.go
@@ -13,6 +13,15 @@ import (
 type Config struct {
 	ManagedGithubClient *github.Client
 	RawGithubv4Client   *githubv4.Client
+	Redirects           map[string]string
+}
+
+func (c Config) EffectiveNamespace(namespace string) string {
+	if redirect, ok := c.Redirects[namespace]; ok {
+		return redirect
+	}
+
+	return namespace
 }
 
 func RouteHandlers(config Config) map[string]LambdaFunc {


### PR DESCRIPTION
Closes #17

If a particular namespace does not publish providers in the GitHub releases, an environment variable `PROVIDER_NAMESPACE_REDIRECTS` allows mapping it to a namespace that mirrors it.