### PR TITLE
Resolved issue where provider download was not resolving repository names

### DIFF
--- a/lambda/providerDownload.go
+++ b/lambda/providerDownload.go
@@ -36,7 +36,7 @@ func downloadProviderVersion(config Config) LambdaFunc {
 			return NotFoundResponse, nil
 		}
 
-		versionDownloadResponse, err := providers.GetVersion(ctx, config.RawGithubv4Client, effectiveNamespace, params.Type, params.Version, params.OS, params.Architecture)
+		versionDownloadResponse, err := providers.GetVersion(ctx, config.RawGithubv4Client, effectiveNamespace, repoName, params.Version, params.OS, params.Architecture)
 		if err != nil {
 			// log the error too for dev
 			fmt.Printf("error fetching version: %s\n", err)


### PR DESCRIPTION
Quick fix to make sure that we use the inferred repo name rather than the type name here on provider downloads. 