### PR TITLE
append domain name to github secret

### DIFF
--- a/secrets.tf
+++ b/secrets.tf
@@ -1,5 +1,5 @@
 resource "aws_secretsmanager_secret" "github_api_token" {
-  name = "github_api_token"
+  name = "${domain_name}-github_api_token"
 }
 
 resource "aws_secretsmanager_secret_version" "github_api_token" {


### PR DESCRIPTION
AWS limits one secret per account by the same name, if we want to have a sandbox with multiple registries under the same AWS account we need it to be dynamic

Fixes #42