### PR TITLE
Create DynamoDB table for storing provider versions

### DIFF
--- a/dynamo.tf
+++ b/dynamo.tf
@@ -1,0 +1,11 @@
+resource "aws_dynamodb_table" "provider_versions" {
+  name         = "provider-versions"
+  billing_mode = "PAY_PER_REQUEST"
+
+  hash_key     = "provider"
+
+  attribute {
+    name = "provider"
+    type = "S"
+  }
+}

--- a/iam.tf
+++ b/iam.tf
@@ -83,3 +83,35 @@ resource "aws_iam_role_policy_attachment" "lambda_logging_policy_attachment" {
   role       = aws_iam_role.lambda.id
   policy_arn = aws_iam_policy.function_logging_policy.arn
 }
+
+data "aws_iam_policy_document" "dynamodb_policy" {
+  statement {
+    effect = "Allow"
+    actions = [
+      "dynamodb:DescribeTable",
+      "dynamodb:Query",
+      "dynamodb:Scan",
+      "dynamodb:GetItem",
+      "dynamodb:BatchGetItem",
+      "dynamodb:PutItem",
+      "dynamodb:UpdateItem",
+      "dynamodb:DeleteItem",
+      "dynamodb:BatchWriteItem"
+    ]
+
+    resources = [
+      aws_dynamodb_table.provider_versions.arn
+    ]
+  }
+}
+
+resource "aws_iam_policy" "lambda_dynamo_policy" {
+  name        = "${var.domain_name}-RegistryLambdaDynamoPolicy"
+  description = "Policy for lambda to Read and Write to the provider versions DynamoDB table"
+  policy      = data.aws_iam_policy_document.dynamodb_policy.json
+}
+
+resource "aws_iam_role_policy_attachment" "lambda_dynamo_policy_attachment" {
+  role       = aws_iam_role.lambda.id
+  policy_arn = aws_iam_policy.lambda_dynamo_policy.arn
+}


### PR DESCRIPTION
Create an on-demand (should still be in the free tier, depending on usage) DynamoDB table that stores the provider versions for each provider

It has single hash key on field "provider"

Also give lambda(s) permissions to all read and write actions in the DDB table