### PR TITLE
all: rename module name to github.com/opentofu/registry and sort imports

### DIFF
--- a/src/go.mod
+++ b/src/go.mod
@@ -1,4 +1,4 @@
-module github.com/opentffoundation/registry
+module github.com/opentofu/registry
 
 go 1.20
 

--- a/src/internal/config/config.go
+++ b/src/internal/config/config.go
@@ -4,16 +4,18 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
+
 	"github.com/aws/aws-sdk-go-v2/aws"
 	awsconfig "github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/lambda"
 	"github.com/aws/aws-xray-sdk-go/xray"
 	gogithub "github.com/google/go-github/v54/github"
-	"github.com/opentffoundation/registry/internal/github"
-	"github.com/opentffoundation/registry/internal/providers/providercache"
-	"github.com/opentffoundation/registry/internal/secrets"
 	"github.com/shurcooL/githubv4"
-	"os"
+
+	"github.com/opentofu/registry/internal/github"
+	"github.com/opentofu/registry/internal/providers/providercache"
+	"github.com/opentofu/registry/internal/secrets"
 )
 
 type ConfigBuilder struct {

--- a/src/internal/github/client.go
+++ b/src/internal/github/client.go
@@ -2,11 +2,12 @@ package github
 
 import (
 	"context"
+	"net/http"
+
 	"github.com/aws/aws-xray-sdk-go/xray"
 	"github.com/google/go-github/v54/github"
 	"github.com/shurcooL/githubv4"
 	"golang.org/x/oauth2"
-	"net/http"
 )
 
 func getGithubOauth2Client(token string) *http.Client {

--- a/src/internal/modules/versions.go
+++ b/src/internal/modules/versions.go
@@ -8,7 +8,7 @@ import (
 	"github.com/aws/aws-xray-sdk-go/xray"
 	"github.com/shurcooL/githubv4"
 
-	"github.com/opentffoundation/registry/internal/github"
+	"github.com/opentofu/registry/internal/github"
 )
 
 // TODO: doc

--- a/src/internal/providers/keys_test.go
+++ b/src/internal/providers/keys_test.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/opentffoundation/registry/internal/providers"
+	"github.com/opentofu/registry/internal/providers"
 )
 
 func TestKeysForNamespace(t *testing.T) {

--- a/src/internal/providers/manifest.go
+++ b/src/internal/providers/manifest.go
@@ -3,8 +3,9 @@ package providers
 import (
 	"context"
 	"encoding/json"
-	"github.com/opentffoundation/registry/internal/github"
 	"io"
+
+	"github.com/opentofu/registry/internal/github"
 )
 
 type Manifest struct {

--- a/src/internal/providers/providercache/fetch.go
+++ b/src/internal/providers/providercache/fetch.go
@@ -2,6 +2,7 @@ package providercache
 
 import (
 	"context"
+
 	"github.com/aws/aws-sdk-go-v2/feature/dynamodb/attributevalue"
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb/types"

--- a/src/internal/providers/providercache/store.go
+++ b/src/internal/providers/providercache/store.go
@@ -3,11 +3,13 @@ package providercache
 import (
 	"context"
 	"fmt"
+	"time"
+
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/feature/dynamodb/attributevalue"
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
-	"github.com/opentffoundation/registry/internal/providers"
-	"time"
+
+	"github.com/opentofu/registry/internal/providers"
 )
 
 type Handler struct {

--- a/src/internal/providers/types.go
+++ b/src/internal/providers/types.go
@@ -1,7 +1,7 @@
 package providers
 
 import (
-	"github.com/opentffoundation/registry/internal/platform"
+	"github.com/opentofu/registry/internal/platform"
 )
 
 // Version represents an individual provider version.

--- a/src/internal/providers/utils.go
+++ b/src/internal/providers/utils.go
@@ -7,8 +7,9 @@ import (
 	"strings"
 
 	"github.com/aws/aws-xray-sdk-go/xray"
-	"github.com/opentffoundation/registry/internal/github"
-	"github.com/opentffoundation/registry/internal/platform"
+
+	"github.com/opentofu/registry/internal/github"
+	"github.com/opentofu/registry/internal/platform"
 )
 
 func getShaSum(ctx context.Context, downloadURL string, filename string) (shaSum string, err error) {

--- a/src/internal/providers/versions.go
+++ b/src/internal/providers/versions.go
@@ -7,8 +7,9 @@ import (
 	"sync"
 
 	"github.com/aws/aws-xray-sdk-go/xray"
-	"github.com/opentffoundation/registry/internal/github"
 	"github.com/shurcooL/githubv4"
+
+	"github.com/opentofu/registry/internal/github"
 )
 
 // GetVersions fetches and returns a list of available versions of a given  provider hosted on GitHub.

--- a/src/internal/secrets/secretsmanager.go
+++ b/src/internal/secrets/secretsmanager.go
@@ -3,9 +3,10 @@ package secrets
 import (
 	"context"
 	"fmt"
+	"os"
+
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/secretsmanager"
-	"os"
 )
 
 type Handler struct {

--- a/src/lambda/api/main.go
+++ b/src/lambda/api/main.go
@@ -2,9 +2,11 @@ package main
 
 import (
 	"context"
+
 	"github.com/aws/aws-lambda-go/events"
 	"github.com/aws/aws-lambda-go/lambda"
-	"github.com/opentffoundation/registry/internal/config"
+
+	"github.com/opentofu/registry/internal/config"
 )
 
 type LambdaFunc func(context.Context, events.APIGatewayProxyRequest) (events.APIGatewayProxyResponse, error)

--- a/src/lambda/api/moduleDownload.go
+++ b/src/lambda/api/moduleDownload.go
@@ -3,12 +3,12 @@ package main
 import (
 	"context"
 	"fmt"
-	"github.com/opentffoundation/registry/internal/config"
 
 	"github.com/aws/aws-lambda-go/events"
 
-	"github.com/opentffoundation/registry/internal/github"
-	"github.com/opentffoundation/registry/internal/modules"
+	"github.com/opentofu/registry/internal/config"
+	"github.com/opentofu/registry/internal/github"
+	"github.com/opentofu/registry/internal/modules"
 )
 
 type DownloadModuleHandlerPathParams struct {

--- a/src/lambda/api/moduleVersions.go
+++ b/src/lambda/api/moduleVersions.go
@@ -3,12 +3,12 @@ package main
 import (
 	"context"
 	"encoding/json"
-	"github.com/opentffoundation/registry/internal/config"
 
 	"github.com/aws/aws-lambda-go/events"
 
-	"github.com/opentffoundation/registry/internal/github"
-	"github.com/opentffoundation/registry/internal/modules"
+	"github.com/opentofu/registry/internal/config"
+	"github.com/opentofu/registry/internal/github"
+	"github.com/opentofu/registry/internal/modules"
 )
 
 type ListModuleVersionsPathParams struct {

--- a/src/lambda/api/providerDownload.go
+++ b/src/lambda/api/providerDownload.go
@@ -4,12 +4,12 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/opentffoundation/registry/internal/config"
 
 	"github.com/aws/aws-lambda-go/events"
 
-	"github.com/opentffoundation/registry/internal/github"
-	"github.com/opentffoundation/registry/internal/providers"
+	"github.com/opentofu/registry/internal/config"
+	"github.com/opentofu/registry/internal/github"
+	"github.com/opentofu/registry/internal/providers"
 )
 
 type DownloadHandlerPathParams struct {

--- a/src/lambda/api/providerVersions.go
+++ b/src/lambda/api/providerVersions.go
@@ -4,15 +4,17 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
+	"time"
+
 	"github.com/aws/aws-lambda-go/events"
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/lambda"
-	"github.com/opentffoundation/registry/internal/config"
-	"github.com/opentffoundation/registry/internal/github"
-	"github.com/opentffoundation/registry/internal/providers"
-	"github.com/opentffoundation/registry/internal/providers/providercache"
-	"os"
-	"time"
+
+	"github.com/opentofu/registry/internal/config"
+	"github.com/opentofu/registry/internal/github"
+	"github.com/opentofu/registry/internal/providers"
+	"github.com/opentofu/registry/internal/providers/providercache"
 )
 
 const providerCacheAge = 1 * time.Hour

--- a/src/lambda/api/router.go
+++ b/src/lambda/api/router.go
@@ -3,11 +3,12 @@ package main
 import (
 	"context"
 	"fmt"
-	"github.com/aws/aws-xray-sdk-go/xray"
-	"github.com/opentffoundation/registry/internal/config"
 	"regexp"
 
 	"github.com/aws/aws-lambda-go/events"
+	"github.com/aws/aws-xray-sdk-go/xray"
+
+	"github.com/opentofu/registry/internal/config"
 )
 
 func RouteHandlers(config config.Config) map[string]LambdaFunc {

--- a/src/lambda/api/terraformWellKnown.go
+++ b/src/lambda/api/terraformWellKnown.go
@@ -2,8 +2,10 @@ package main
 
 import (
 	"context"
+
 	"github.com/aws/aws-lambda-go/events"
-	"github.com/opentffoundation/registry/internal/config"
+
+	"github.com/opentofu/registry/internal/config"
 )
 
 const wellKnownMetadataResponse = `{

--- a/src/lambda/populate_provider_versions/handler.go
+++ b/src/lambda/populate_provider_versions/handler.go
@@ -3,10 +3,12 @@ package main
 import (
 	"context"
 	"fmt"
+
 	"github.com/aws/aws-xray-sdk-go/xray"
-	"github.com/opentffoundation/registry/internal/config"
-	"github.com/opentffoundation/registry/internal/github"
-	"github.com/opentffoundation/registry/internal/providers"
+
+	"github.com/opentofu/registry/internal/config"
+	"github.com/opentofu/registry/internal/github"
+	"github.com/opentofu/registry/internal/providers"
 )
 
 type PopulateProviderVersionsEvent struct {

--- a/src/lambda/populate_provider_versions/main.go
+++ b/src/lambda/populate_provider_versions/main.go
@@ -3,8 +3,10 @@ package main
 import (
 	"context"
 	"fmt"
+
 	"github.com/aws/aws-lambda-go/lambda"
-	"github.com/opentffoundation/registry/internal/config"
+
+	"github.com/opentofu/registry/internal/config"
 )
 
 func main() {


### PR DESCRIPTION
OpenTofu organization has been renamed from `opentffoundation`, but there is still use of the previous name in the Go module.
Rename it and sort the import section via `goimports`.