### PR TITLE
Only update document in dynamodb if it's too old

### DIFF
--- a/src/internal/providers/providercache/store.go
+++ b/src/internal/providers/providercache/store.go
@@ -25,6 +25,8 @@ func NewHandler(awsConfig aws.Config, tableName string) *Handler {
 	}
 }
 
+const AllowedAge = 1 * time.Hour
+
 type VersionListingItem struct {
 	Provider    string              `dynamodbav:"provider"`
 	Versions    []providers.Version `dynamodbav:"versions"`

--- a/src/lambda/api/providerVersions.go
+++ b/src/lambda/api/providerVersions.go
@@ -69,7 +69,8 @@ func listProviderVersions(config config.Config) LambdaFunc {
 func processDocument(ctx context.Context, document *providercache.VersionListingItem, config config.Config, namespace, providerType string) (events.APIGatewayProxyResponse, error) {
 	fmt.Printf("Found document with %d versions, last_updated: %s\n", len(document.Versions), document.LastUpdated.String())
 
-	if document.LastUpdated.After(time.Now().Add(-providercache.AllowedAge)) {
+	oldestAllowedAge := time.Now().Add(-providercache.AllowedAge)
+	if document.LastUpdated.After(oldestAllowedAge) {
 		fmt.Printf("Document is recent enough, returning it\n")
 		return versionsResponse(document.Versions)
 	}

--- a/src/lambda/api/providerVersions.go
+++ b/src/lambda/api/providerVersions.go
@@ -69,8 +69,7 @@ func listProviderVersions(config config.Config) LambdaFunc {
 func processDocument(ctx context.Context, document *providercache.VersionListingItem, config config.Config, namespace, providerType string) (events.APIGatewayProxyResponse, error) {
 	fmt.Printf("Found document with %d versions, last_updated: %s\n", len(document.Versions), document.LastUpdated.String())
 
-	oldestAllowedAge := time.Now().Add(-providercache.AllowedAge)
-	if document.LastUpdated.After(oldestAllowedAge) {
+	if time.Since(document.LastUpdated) < providercache.AllowedAge {
 		fmt.Printf("Document is recent enough, returning it\n")
 		return versionsResponse(document.Versions)
 	}

--- a/src/lambda/api/providerVersions.go
+++ b/src/lambda/api/providerVersions.go
@@ -17,8 +17,6 @@ import (
 	"github.com/opentffoundation/registry/internal/providers/providercache"
 )
 
-const providerCacheAge = 1 * time.Hour
-
 type ListProvidersPathParams struct {
 	Namespace string `json:"namespace"`
 	Type      string `json:"name"`
@@ -71,7 +69,7 @@ func listProviderVersions(config config.Config) LambdaFunc {
 func processDocument(ctx context.Context, document *providercache.VersionListingItem, config config.Config, namespace, providerType string) (events.APIGatewayProxyResponse, error) {
 	fmt.Printf("Found document with %d versions, last_updated: %s\n", len(document.Versions), document.LastUpdated.String())
 
-	if document.LastUpdated.After(time.Now().Add(-providerCacheAge)) {
+	if document.LastUpdated.After(time.Now().Add(-providercache.AllowedAge)) {
 		fmt.Printf("Document is recent enough, returning it\n")
 		return versionsResponse(document.Versions)
 	}

--- a/src/lambda/populate_provider_versions/handler.go
+++ b/src/lambda/populate_provider_versions/handler.go
@@ -51,7 +51,8 @@ func HandleRequest(config *config.Config) LambdaFunc {
 				fmt.Printf("Error: failed to get item from cache: %s", err.Error())
 			}
 			if document != nil {
-				if document.LastUpdated.After(time.Now().Add(-providercache.AllowedAge)) {
+				oldestAllowedAge := time.Now().Add(-providercache.AllowedAge)
+				if document.LastUpdated.After(oldestAllowedAge) {
 					fmt.Printf("Document is up to date, not updating\n")
 					return nil
 				}

--- a/src/lambda/populate_provider_versions/handler.go
+++ b/src/lambda/populate_provider_versions/handler.go
@@ -3,13 +3,13 @@ package main
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/aws/aws-xray-sdk-go/xray"
 	"github.com/opentffoundation/registry/internal/config"
 	"github.com/opentffoundation/registry/internal/github"
 	"github.com/opentffoundation/registry/internal/providers"
 	"github.com/opentffoundation/registry/internal/providers/providercache"
-	"time"
 )
 
 type PopulateProviderVersionsEvent struct {
@@ -51,8 +51,7 @@ func HandleRequest(config *config.Config) LambdaFunc {
 				fmt.Printf("Error: failed to get item from cache: %s", err.Error())
 			}
 			if document != nil {
-				oldestAllowedAge := time.Now().Add(-providercache.AllowedAge)
-				if document.LastUpdated.After(oldestAllowedAge) {
+				if time.Since(document.LastUpdated) < providercache.AllowedAge {
 					fmt.Printf("Document is up to date, not updating\n")
 					return nil
 				}


### PR DESCRIPTION
This PR moves the `providerCacheAge` to a central location so it can be used by both lambdas. But more importantly it introduces a process to check if the document needs updating.

This should reduce a small about of unnecessary requests made to github for versions that are already updated.