### PR TITLE
Update api gateway caching to 65 minutes

### DIFF
--- a/apigw.tf
+++ b/apigw.tf
@@ -298,7 +298,8 @@ resource "aws_api_gateway_method_settings" "download_method_settings" {
   settings {
     metrics_enabled                         = true
     caching_enabled                         = true
-    cache_ttl_in_seconds                    = 3600
+    // 65 minutes to keep it consistent with the provider versions cache TTL
+    cache_ttl_in_seconds                    = (65*60)
     require_authorization_for_cache_control = false
   }
 }
@@ -313,7 +314,8 @@ resource "aws_api_gateway_method_settings" "provider_list_versions_method_settin
   settings {
     metrics_enabled                         = true
     caching_enabled                         = true
-    cache_ttl_in_seconds                    = 3600
+    // 65 minutes, to ensure we're over the (current) one hour limit of backend cache TTL
+    cache_ttl_in_seconds                    = (65*60)
     require_authorization_for_cache_control = false
   }
 }
@@ -328,7 +330,9 @@ resource "aws_api_gateway_method_settings" "module_download_method_settings" {
   settings {
     metrics_enabled                         = true
     caching_enabled                         = true
-    cache_ttl_in_seconds                    = 3600
+
+    // 65 minutes to keep it consistent with the provider versions cache TTL
+    cache_ttl_in_seconds                    = (65*60)
     require_authorization_for_cache_control = false
   }
 }
@@ -343,7 +347,8 @@ resource "aws_api_gateway_method_settings" "module_list_versions_method_settings
   settings {
     metrics_enabled                         = true
     caching_enabled                         = true
-    cache_ttl_in_seconds                    = 3600
+    // 65 minutes to keep it consistent with the provider versions cache TTL
+    cache_ttl_in_seconds                    = (65*60)
     require_authorization_for_cache_control = false
   }
 }
@@ -358,7 +363,8 @@ resource "aws_api_gateway_method_settings" "well_known_method_settings" {
   settings {
     metrics_enabled                         = true
     caching_enabled                         = true
-    cache_ttl_in_seconds                    = 3600
+    // 65 minutes to keep it consistent with the provider versions cache TTL
+    cache_ttl_in_seconds                    = (65*60)
     require_authorization_for_cache_control = false
   }
 }


### PR DESCRIPTION
## Summary

This PR extends the Time-to-Live (TTL) setting for the API Gateway cache from 60 to 65 minutes. This change is aimed at reducing the number of cache misses and thus lowering the risk of hitting GitHub rate-limits. 

## Changes

- Updated `cache_ttl_in_seconds` in various method settings from `3600` (60 minutes) to `3900` (65 minutes).

## Rationale

1. **Alignment with Backend Cache**: Our DynamoDB cache considers documents "old" after 1 hour. Extending the API Gateway cache to 65 minutes provides a 5-minute buffer, making it less likely we'll have to refresh data from GitHub.
   
2. **Consistency Across Layers**: With a 65-minute TTL at both DynamoDB and API Gateway, we achieve uniform cache behavior across our stack. This makes the cache logic easier to understand and maintain.
  
3. **Optimized API Calls**: The extended TTL reduces the need to make additional API calls to GitHub, aiding in staying below rate-limiting thresholds.

## Implications

- **Stale Data Risk**: A 65-minute cache period might serve slightly stale data, particularly during the last 5 minutes. This trade-off is considered acceptable when weighed against the benefit of rate-limiting mitigation.

## Monitoring and Next Steps

Post-deployment, it will be essential to:

- Monitor cache hit/miss ratios.
- Reevaluate the setup for any cost implications or performance bottlenecks.