### PR TITLE
Introduce golangci-lint to keep a clean codebase

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,26 @@
+name: golangci-lint
+on:
+  push:
+    branches:
+      - master
+      - main
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  golangci:
+    name: lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-go@v4
+        with:
+          go-version: '1.21'
+          cache: false
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v3
+        with:
+          version: v1.54
+          working-directory: src

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -24,3 +24,4 @@ jobs:
         with:
           version: v1.54
           working-directory: src
+          args: --timeout=10m

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,10 +15,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+
       - uses: actions/setup-go@v4
-        with:
-          go-version: '1.21'
-          cache: false
+        with: { go-version-file: 'src/go.mod' }
+
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:

--- a/src/.golangci.yml
+++ b/src/.golangci.yml
@@ -82,7 +82,6 @@ linters:
     - stylecheck
     - tenv
     - testableexamples
-    - testpackage
     - tparallel
     - typecheck
     - unconvert

--- a/src/.golangci.yml
+++ b/src/.golangci.yml
@@ -70,7 +70,7 @@ linters:
     - nilnil
     - noctx
     - nolintlint
-    - nonamedreturns
+  # - nonamedreturns # Disabling for now until we introduce structured logging (and pull out xray)
     - nosprintfhostport
     - predeclared
     - promlinter

--- a/src/.golangci.yml
+++ b/src/.golangci.yml
@@ -12,8 +12,15 @@ linters-settings:
       - switch
       - map
 
+  funlen:
+    lines: 100
+    statements: 50
+    ignore-comments: true
+
   govet:
     enable-all: true
+    disable:
+      - fieldalignment # rule is too strict
 
   nolintlint:
     require-explanation: true

--- a/src/.golangci.yml
+++ b/src/.golangci.yml
@@ -1,0 +1,86 @@
+run:
+  timeout: 1m
+
+linters-settings:
+  errcheck:
+    check-type-assertions: true
+
+  exhaustive:
+    check:
+      - switch
+      - map
+
+  govet:
+    enable-all: true
+
+  nolintlint:
+    require-explanation: true
+    require-specific: true
+
+linters:
+  disable-all: true
+  enable:
+    - asasalint
+    - asciicheck
+    - bidichk
+    - bodyclose
+    - cyclop
+    - dupl
+    - durationcheck
+    - errcheck
+    - errname
+    - errorlint
+    - execinquery
+    - exhaustive
+    - exportloopref
+    - forbidigo
+    - funlen
+    - gocheckcompilerdirectives
+    - gochecknoglobals
+    - gochecknoinits
+    - gocognit
+    - goconst
+    - gocritic
+    - gocyclo
+    - godot
+    - goimports
+    - gomnd
+    - gomoddirectives
+    - gomodguard
+    - goprintffuncname
+    - gosec
+    - gosimple
+    - govet
+    - ineffassign
+    - lll
+    - loggercheck
+    - makezero
+    - mirror
+    - musttag
+    - nakedret
+    - nestif
+    - nilerr
+    - nilnil
+    - noctx
+    - nolintlint
+    - nonamedreturns
+    - nosprintfhostport
+    - predeclared
+    - promlinter
+    - reassign
+    - revive
+    - rowserrcheck
+    - sqlclosecheck
+    - staticcheck
+    - stylecheck
+    - tenv
+    - testableexamples
+    - testpackage
+    - tparallel
+    - typecheck
+    - unconvert
+    - unparam
+    - unused
+    - usestdlibvars
+    - wastedassign
+    - whitespace 

--- a/src/.golangci.yml
+++ b/src/.golangci.yml
@@ -44,7 +44,6 @@ linters:
     - goconst
     - gocritic
     - gocyclo
-    - godot
     - goimports
     - gomnd
     - gomoddirectives

--- a/src/.golangci.yml
+++ b/src/.golangci.yml
@@ -60,7 +60,6 @@ linters:
     - gosimple
     - govet
     - ineffassign
-    - lll
     - loggercheck
     - makezero
     - mirror

--- a/src/.golangci.yml
+++ b/src/.golangci.yml
@@ -4,6 +4,8 @@ run:
 linters-settings:
   errcheck:
     check-type-assertions: true
+    exclude-functions:
+      github.com/aws/aws-xray-sdk-go/xray.AddAnnotation
 
   exhaustive:
     check:
@@ -33,7 +35,7 @@ linters:
     - execinquery
     - exhaustive
     - exportloopref
-    - forbidigo
+  # - forbidigo # Disabling for now until we introduce structured logging
     - funlen
     - gocheckcompilerdirectives
     - gochecknoglobals

--- a/src/internal/config/config.go
+++ b/src/internal/config/config.go
@@ -52,7 +52,7 @@ type Config struct {
 func (c Builder) BuildConfig(ctx context.Context, xraySegmentName string) (config *Config, err error) {
 	if err = xray.Configure(xray.Config{ServiceVersion: "1.2.3"}); err != nil {
 		err = fmt.Errorf("could not configure X-Ray: %w", err)
-		return
+		return nil, err
 	}
 
 	// At this point we're not part of a Lambda request execution, so let's
@@ -64,7 +64,7 @@ func (c Builder) BuildConfig(ctx context.Context, xraySegmentName string) (confi
 	awsConfig, err = awsconfig.LoadDefaultConfig(ctx, awsconfig.WithRegion(os.Getenv("AWS_REGION")))
 	if err != nil {
 		err = fmt.Errorf("could not load AWS configuration: %w", err)
-		return
+		return nil, err
 	}
 
 	secretsHandler := secrets.NewHandler(awsConfig)
@@ -72,14 +72,14 @@ func (c Builder) BuildConfig(ctx context.Context, xraySegmentName string) (confi
 	githubAPIToken, err := secretsHandler.GetSecretValueFromEnvReference(ctx, "GITHUB_TOKEN_SECRET_ASM_NAME")
 	if err != nil {
 		err = fmt.Errorf("could not get GitHub API token: %w", err)
-		return
+		return nil, err
 	}
 
 	var tableName string
 	tableName = os.Getenv("PROVIDER_VERSIONS_TABLE_NAME")
 	if tableName == "" {
 		err = fmt.Errorf("PROVIDER_VERSIONS_TABLE_NAME environment variable not set")
-		return
+		return nil, err
 	}
 
 	providerRedirects := make(map[string]string)
@@ -101,7 +101,7 @@ func (c Builder) BuildConfig(ctx context.Context, xraySegmentName string) (confi
 
 		ProviderRedirects: providerRedirects,
 	}
-	return
+	return config, nil
 }
 
 // EffectiveProviderNamespace will map namespaces for providers in situations

--- a/src/internal/config/config.go
+++ b/src/internal/config/config.go
@@ -17,20 +17,20 @@ import (
 	"github.com/shurcooL/githubv4"
 )
 
-type ConfigBuilder struct {
+type Builder struct {
 	IncludeProviderRedirects bool
 }
 
-func NewConfigBuilder(options ...func(*ConfigBuilder)) *ConfigBuilder {
-	configBuilder := &ConfigBuilder{}
+func NewBuilder(options ...func(*Builder)) *Builder {
+	configBuilder := &Builder{}
 	for _, option := range options {
 		option(configBuilder)
 	}
 	return configBuilder
 }
 
-func WithProviderRedirects() func(*ConfigBuilder) {
-	return func(builder *ConfigBuilder) {
+func WithProviderRedirects() func(*Builder) {
+	return func(builder *Builder) {
 		builder.IncludeProviderRedirects = true
 	}
 }
@@ -49,7 +49,7 @@ type Config struct {
 // BuildConfig will build a configuration object for the application. This
 // includes loading secrets from AWS Secrets Manager, and configuring the
 // AWS SDK.
-func (c ConfigBuilder) BuildConfig(ctx context.Context, xraySegmentName string) (config *Config, err error) {
+func (c Builder) BuildConfig(ctx context.Context, xraySegmentName string) (config *Config, err error) {
 	if err = xray.Configure(xray.Config{ServiceVersion: "1.2.3"}); err != nil {
 		err = fmt.Errorf("could not configure X-Ray: %w", err)
 		return

--- a/src/internal/config/config.go
+++ b/src/internal/config/config.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
+
 	"github.com/aws/aws-sdk-go-v2/aws"
 	awsconfig "github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/lambda"
@@ -13,7 +15,6 @@ import (
 	"github.com/opentffoundation/registry/internal/providers/providercache"
 	"github.com/opentffoundation/registry/internal/secrets"
 	"github.com/shurcooL/githubv4"
-	"os"
 )
 
 type ConfigBuilder struct {

--- a/src/internal/config/config.go
+++ b/src/internal/config/config.go
@@ -75,8 +75,7 @@ func (c Builder) BuildConfig(ctx context.Context, xraySegmentName string) (confi
 		return nil, err
 	}
 
-	var tableName string
-	tableName = os.Getenv("PROVIDER_VERSIONS_TABLE_NAME")
+	tableName := os.Getenv("PROVIDER_VERSIONS_TABLE_NAME")
 	if tableName == "" {
 		err = fmt.Errorf("PROVIDER_VERSIONS_TABLE_NAME environment variable not set")
 		return nil, err

--- a/src/internal/github/client.go
+++ b/src/internal/github/client.go
@@ -2,11 +2,12 @@ package github
 
 import (
 	"context"
+	"net/http"
+
 	"github.com/aws/aws-xray-sdk-go/xray"
 	"github.com/google/go-github/v54/github"
 	"github.com/shurcooL/githubv4"
 	"golang.org/x/oauth2"
-	"net/http"
 )
 
 func getGithubOauth2Client(token string) *http.Client {

--- a/src/internal/github/github.go
+++ b/src/internal/github/github.go
@@ -39,7 +39,7 @@ type GHRelease struct {
 	IsLatest     bool     // Indicates if the release is the latest.
 	IsPrerelease bool     // Indicates if the release is a prerelease.
 	TagCommit    struct { // The commit associated with the release tag.
-		// nolint: revive // This is a struct provided by the GitHub GraphQL API.
+		// nolint: revive, stylecheck // This is a struct provided by the GitHub GraphQL API.
 		TarballUrl string // The URL to download the release tarball.
 	}
 }

--- a/src/internal/github/github.go
+++ b/src/internal/github/github.go
@@ -198,6 +198,7 @@ func DownloadAssetContents(ctx context.Context, downloadURL string) (body io.Rea
 		if respErr != nil {
 			return fmt.Errorf("error downloading asset: %w", respErr)
 		}
+		defer resp.Body.Close()
 
 		if resp.StatusCode != http.StatusOK {
 			return fmt.Errorf("unexpected status code when downloading asset: %d", resp.StatusCode)

--- a/src/internal/github/github.go
+++ b/src/internal/github/github.go
@@ -91,7 +91,8 @@ func FindRelease(ctx context.Context, ghClient *githubv4.Client, namespace, name
 				}
 
 				if r.TagName == fmt.Sprintf("v%s", versionNumber) {
-					release = &r
+					rCopy := r
+					release = &rCopy
 					return nil
 				}
 			}

--- a/src/internal/github/github.go
+++ b/src/internal/github/github.go
@@ -69,7 +69,7 @@ func RepositoryExists(ctx context.Context, managedGhClient *github.Client, names
 		return nil
 	})
 
-	return
+	return exists, err
 }
 
 func FindRelease(ctx context.Context, ghClient *githubv4.Client, namespace, name, versionNumber string) (release *GHRelease, err error) {
@@ -107,7 +107,7 @@ func FindRelease(ctx context.Context, ghClient *githubv4.Client, namespace, name
 		return nil
 	})
 
-	return
+	return release, err
 }
 
 func FetchReleases(ctx context.Context, ghClient *githubv4.Client, namespace, name string) (releases []GHRelease, err error) {
@@ -141,7 +141,7 @@ func FetchReleases(ctx context.Context, ghClient *githubv4.Client, namespace, na
 		return nil
 	})
 
-	return
+	return releases, err
 }
 
 func initVariables(namespace, name string) map[string]interface{} {
@@ -173,7 +173,7 @@ func FetchReleaseNodes(ctx context.Context, ghClient *githubv4.Client, variables
 		return nil
 	})
 
-	return
+	return releases, endCursor, err
 }
 
 func FindAssetBySuffix(assets []ReleaseAsset, suffix string) *ReleaseAsset {
@@ -209,5 +209,5 @@ func DownloadAssetContents(ctx context.Context, downloadURL string) (body io.Rea
 		return nil
 	})
 
-	return
+	return body, err
 }

--- a/src/internal/github/github.go
+++ b/src/internal/github/github.go
@@ -39,6 +39,7 @@ type GHRelease struct {
 	IsLatest     bool     // Indicates if the release is the latest.
 	IsPrerelease bool     // Indicates if the release is a prerelease.
 	TagCommit    struct { // The commit associated with the release tag.
+		// nolint: revive // This is a struct provided by the GitHub GraphQL API.
 		TarballUrl string // The URL to download the release tarball.
 	}
 }

--- a/src/internal/github/github.go
+++ b/src/internal/github/github.go
@@ -81,8 +81,7 @@ func FindRelease(ctx context.Context, ghClient *githubv4.Client, namespace, name
 
 		for {
 			nodes, endCursor, fetchErr := FetchReleaseNodes(tracedCtx, ghClient, variables)
-
-			if err != nil {
+			if fetchErr != nil {
 				return fmt.Errorf("failed to fetch release nodes: %w", fetchErr)
 			}
 

--- a/src/internal/github/github.go
+++ b/src/internal/github/github.go
@@ -39,7 +39,7 @@ type GHRelease struct {
 	IsLatest     bool     // Indicates if the release is the latest.
 	IsPrerelease bool     // Indicates if the release is a prerelease.
 	TagCommit    struct { // The commit associated with the release tag.
-		// nolint: revive, stylecheck // This is a struct provided by the GitHub GraphQL API.
+		//nolint: revive, stylecheck // This is a struct provided by the GitHub GraphQL API.
 		TarballUrl string // The URL to download the release tarball.
 	}
 }

--- a/src/internal/github/github.go
+++ b/src/internal/github/github.go
@@ -185,8 +185,10 @@ func FindAssetBySuffix(assets []ReleaseAsset, suffix string) *ReleaseAsset {
 	return nil
 }
 
+const githubAssetDownloadTimeout = 60 * time.Second
+
 func DownloadAssetContents(ctx context.Context, downloadURL string) (body io.ReadCloser, err error) {
-	httpClient := xray.Client(&http.Client{Timeout: 60 * time.Second})
+	httpClient := xray.Client(&http.Client{Timeout: githubAssetDownloadTimeout})
 
 	err = xray.Capture(ctx, "github.asset.download", func(tracedCtx context.Context) error {
 		req, reqErr := http.NewRequestWithContext(tracedCtx, http.MethodGet, downloadURL, nil)

--- a/src/internal/modules/versions.go
+++ b/src/internal/modules/versions.go
@@ -32,5 +32,5 @@ func GetVersions(ctx context.Context, ghClient *githubv4.Client, namespace strin
 		return nil
 	})
 
-	return
+	return versions, err
 }

--- a/src/internal/modules/versions.go
+++ b/src/internal/modules/versions.go
@@ -11,7 +11,7 @@ import (
 	"github.com/opentffoundation/registry/internal/github"
 )
 
-// TODO: doc
+// GetVersions fetches a list of versions for a GitHub repository identified by its namespace and name.
 func GetVersions(ctx context.Context, ghClient *githubv4.Client, namespace string, name string) (versions []Version, err error) {
 	err = xray.Capture(ctx, "module.versions", func(tracedCtx context.Context) error {
 		xray.AddAnnotation(tracedCtx, "namespace", namespace)

--- a/src/internal/providers/keys.go
+++ b/src/internal/providers/keys.go
@@ -85,7 +85,7 @@ func buildKey(path string) (*GPGPublicKey, error) {
 	}
 
 	return &GPGPublicKey{
-		AsciiArmor: asciiArmor,
+		ASCIIArmor: asciiArmor,
 		KeyID:      strings.ToUpper(key.GetHexKeyID()),
 	}, nil
 }

--- a/src/internal/providers/keys.go
+++ b/src/internal/providers/keys.go
@@ -81,7 +81,7 @@ func buildKey(path string) (*GPGPublicKey, error) {
 
 	key, err := crypto.NewKeyFromArmored(asciiArmor)
 	if err != nil {
-		return nil, fmt.Errorf("could not build public key from ascii armor: %v", err)
+		return nil, fmt.Errorf("could not build public key from ascii armor: %w", err)
 	}
 
 	return &GPGPublicKey{

--- a/src/internal/providers/keys_test.go
+++ b/src/internal/providers/keys_test.go
@@ -24,7 +24,7 @@ func TestKeysForNamespace(t *testing.T) {
 			t.Fatalf("expected key ID to be E302FB5AA29D88F7, got %s", keys[0].KeyID)
 		}
 
-		if !strings.HasPrefix(keys[0].AsciiArmor, "-----BEGIN PGP PUBLIC KEY BLOCK-----") {
+		if !strings.HasPrefix(keys[0].ASCIIArmor, "-----BEGIN PGP PUBLIC KEY BLOCK-----") {
 			t.Fatalf("expected key to have ascii armor, got empty string")
 		}
 	})

--- a/src/internal/providers/manifest.go
+++ b/src/internal/providers/manifest.go
@@ -22,7 +22,7 @@ func findAndParseManifest(ctx context.Context, assets []github.ReleaseAsset) (*M
 		return nil, nil //nolint:nilnil // This is not an error, it just means there is no manifest.
 	}
 
-assetContents, err := github.DownloadAssetContents(ctx, manifestAsset.DownloadURL)
+	assetContents, err := github.DownloadAssetContents(ctx, manifestAsset.DownloadURL)
 	if err != nil {
 		return nil, err
 	}

--- a/src/internal/providers/manifest.go
+++ b/src/internal/providers/manifest.go
@@ -19,10 +19,10 @@ type ManifestMetadata struct {
 func findAndParseManifest(ctx context.Context, assets []github.ReleaseAsset) (*Manifest, error) {
 	manifestAsset := github.FindAssetBySuffix(assets, "_manifest.json")
 	if manifestAsset == nil {
-		return nil, nil
+		return nil, nil //nolint:nilnil // This is not an error, it just means there is no manifest.
 	}
 
-	assetContents, err := github.DownloadAssetContents(ctx, manifestAsset.DownloadURL)
+assetContents, err := github.DownloadAssetContents(ctx, manifestAsset.DownloadURL)
 	if err != nil {
 		return nil, err
 	}

--- a/src/internal/providers/manifest.go
+++ b/src/internal/providers/manifest.go
@@ -3,8 +3,9 @@ package providers
 import (
 	"context"
 	"encoding/json"
-	"github.com/opentffoundation/registry/internal/github"
 	"io"
+
+	"github.com/opentffoundation/registry/internal/github"
 )
 
 type Manifest struct {

--- a/src/internal/providers/providercache/fetch.go
+++ b/src/internal/providers/providercache/fetch.go
@@ -21,7 +21,7 @@ func (p *Handler) GetItem(ctx context.Context, key string) (*VersionListingItem,
 
 	// check if the item is empty, if so return nil, this makes it easier to consume in other places
 	if len(result.Item) == 0 {
-		return nil, nil
+		return nil, nil //nolint:nilnil // This is not an error, it just means there is no manifest.
 	}
 
 	var item VersionListingItem

--- a/src/internal/providers/providercache/fetch.go
+++ b/src/internal/providers/providercache/fetch.go
@@ -2,6 +2,7 @@ package providercache
 
 import (
 	"context"
+
 	"github.com/aws/aws-sdk-go-v2/feature/dynamodb/attributevalue"
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb/types"

--- a/src/internal/providers/providercache/store.go
+++ b/src/internal/providers/providercache/store.go
@@ -3,11 +3,12 @@ package providercache
 import (
 	"context"
 	"fmt"
+	"time"
+
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/feature/dynamodb/attributevalue"
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
 	"github.com/opentffoundation/registry/internal/providers"
-	"time"
 )
 
 type Handler struct {

--- a/src/internal/providers/types.go
+++ b/src/internal/providers/types.go
@@ -36,5 +36,5 @@ type SigningKeys struct {
 // GPGPublicKey represents an individual GPG public key.
 type GPGPublicKey struct {
 	KeyID      string `json:"key_id"`      // The ID of the GPG key.
-	AsciiArmor string `json:"ascii_armor"` // The ASCII armored representation of the GPG public key.
+	ASCIIArmor string `json:"ascii_armor"` // The ASCII armored representation of the GPG public key.
 }

--- a/src/internal/providers/utils.go
+++ b/src/internal/providers/utils.go
@@ -39,7 +39,7 @@ func getShaSum(ctx context.Context, downloadURL string, filename string) (shaSum
 	return
 }
 
-func getSupportedArchAndOS(assets []github.ReleaseAsset) ([]platform.Platform, error) {
+func getSupportedArchAndOS(assets []github.ReleaseAsset) []platform.Platform {
 	var platforms []platform.Platform
 	for _, asset := range assets {
 		platform := platform.ExtractPlatformFromArtifact(asset.Name)
@@ -48,5 +48,5 @@ func getSupportedArchAndOS(assets []github.ReleaseAsset) ([]platform.Platform, e
 		}
 		platforms = append(platforms, *platform)
 	}
-	return platforms, nil
+	return platforms
 }

--- a/src/internal/providers/versions.go
+++ b/src/internal/providers/versions.go
@@ -90,7 +90,10 @@ func GetVersions(ctx context.Context, ghClient *githubv4.Client, namespace strin
 		for vr := range versionCh {
 			if vr.Err != nil {
 				// we don't want to fail the entire operation if one version fails, just trace the error and continue
-				xray.AddError(tracedCtx, fmt.Errorf("failed to process some releases: %w", vr.Err))
+				xrayErr := xray.AddError(tracedCtx, fmt.Errorf("failed to process some releases: %w", vr.Err))
+				if xrayErr != nil {
+					return fmt.Errorf("failed to add error to trace: %w", err)
+				}
 			}
 			if vr.Version.Version != "" {
 				versions = append(versions, vr.Version)

--- a/src/internal/providers/versions.go
+++ b/src/internal/providers/versions.go
@@ -122,17 +122,17 @@ func getVersionFromGithubRelease(ctx context.Context, r github.GHRelease, versio
 // - namespace: The GitHub namespace (typically, the organization or user) under which the provider repository is hosted.
 // - name: The name of the provider without the "terraform-provider-" prefix.
 // - version: The specific version of the Terraform provider to fetch details for.
-// - OS: The operating system for which the provider binary is intended.
+// - os: The operating system for which the provider binary is intended.
 // - arch: The architecture for which the provider binary is intended.
 //
 // Returns a VersionDetails structure with detailed information about the specified version. If an error occurs during fetching or processing, it returns an error.
 
-func GetVersion(ctx context.Context, ghClient *githubv4.Client, namespace string, name string, version string, OS string, arch string) (versionDetails *VersionDetails, err error) {
+func GetVersion(ctx context.Context, ghClient *githubv4.Client, namespace string, name string, version string, os string, arch string) (versionDetails *VersionDetails, err error) {
 	err = xray.Capture(ctx, "provider.versiondetails", func(tracedCtx context.Context) error {
 		xray.AddAnnotation(tracedCtx, "namespace", namespace)
 		xray.AddAnnotation(tracedCtx, "name", name)
 		xray.AddAnnotation(tracedCtx, "version", version)
-		xray.AddAnnotation(tracedCtx, "OS", OS)
+		xray.AddAnnotation(tracedCtx, "OS", os)
 		xray.AddAnnotation(tracedCtx, "arch", arch)
 
 		// Fetch the specific release for the given version.
@@ -147,7 +147,7 @@ func GetVersion(ctx context.Context, ghClient *githubv4.Client, namespace string
 
 		// Initialize the VersionDetails struct.
 		versionDetails = &VersionDetails{
-			OS:   OS,
+			OS:   os,
 			Arch: arch,
 		}
 
@@ -166,7 +166,7 @@ func GetVersion(ctx context.Context, ghClient *githubv4.Client, namespace string
 		}
 
 		// Identify the appropriate asset for download based on OS and architecture.
-		assetToDownload := github.FindAssetBySuffix(release.ReleaseAssets.Nodes, fmt.Sprintf("_%s_%s.zip", OS, arch))
+		assetToDownload := github.FindAssetBySuffix(release.ReleaseAssets.Nodes, fmt.Sprintf("_%s_%s.zip", os, arch))
 		if assetToDownload == nil {
 			return fmt.Errorf("could not find asset to download")
 		}

--- a/src/internal/providers/versions.go
+++ b/src/internal/providers/versions.go
@@ -77,12 +77,7 @@ func getVersionFromGithubRelease(ctx context.Context, r github.GHRelease, versio
 	result := versionResult{}
 
 	assets := r.ReleaseAssets.Nodes
-	platforms, platformsErr := getSupportedArchAndOS(assets)
-	if platformsErr != nil {
-		result.Err = fmt.Errorf("failed to get supported platforms: %w", platformsErr)
-		versionCh <- result
-		return
-	}
+	platforms := getSupportedArchAndOS(assets)
 
 	// if there are no platforms, we can't do anything with this release
 	// so, we should just skip

--- a/src/internal/providers/versions.go
+++ b/src/internal/providers/versions.go
@@ -68,7 +68,7 @@ func GetVersions(ctx context.Context, ghClient *githubv4.Client, namespace strin
 		return nil
 	})
 
-	return
+	return versions, err
 }
 
 // getVersionFromGithubRelease fetches and returns detailed information about a specific version of a provider hosted on GitHub.
@@ -203,5 +203,5 @@ func GetVersion(ctx context.Context, ghClient *githubv4.Client, namespace string
 		return nil
 	})
 
-	return
+	return versionDetails, err
 }

--- a/src/internal/secrets/secretsmanager.go
+++ b/src/internal/secrets/secretsmanager.go
@@ -3,9 +3,10 @@ package secrets
 import (
 	"context"
 	"fmt"
+	"os"
+
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/secretsmanager"
-	"os"
 )
 
 type Handler struct {

--- a/src/lambda/api/main.go
+++ b/src/lambda/api/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+
 	"github.com/aws/aws-lambda-go/events"
 	"github.com/aws/aws-lambda-go/lambda"
 	"github.com/opentffoundation/registry/internal/config"

--- a/src/lambda/api/main.go
+++ b/src/lambda/api/main.go
@@ -11,7 +11,7 @@ import (
 type LambdaFunc func(context.Context, events.APIGatewayProxyRequest) (events.APIGatewayProxyResponse, error)
 
 func main() {
-	configBuilder := config.NewConfigBuilder(config.WithProviderRedirects())
+	configBuilder := config.NewBuilder(config.WithProviderRedirects())
 
 	config, err := configBuilder.BuildConfig(context.Background(), "registry.buildconfig")
 	if err != nil {

--- a/src/lambda/api/moduleDownload.go
+++ b/src/lambda/api/moduleDownload.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"net/http"
 
 	"github.com/opentffoundation/registry/internal/config"
 
@@ -28,14 +29,14 @@ func downloadModuleVersion(config config.Config) LambdaFunc {
 		// check if the repo exists
 		exists, err := github.RepositoryExists(ctx, config.ManagedGithubClient, params.Namespace, repoName)
 		if err != nil {
-			return events.APIGatewayProxyResponse{StatusCode: 500}, err
+			return events.APIGatewayProxyResponse{StatusCode: http.StatusInternalServerError}, err
 		}
 
 		if !exists {
 			return NotFoundResponse, nil
 		}
 
-		return events.APIGatewayProxyResponse{StatusCode: 200, Body: "", Headers: map[string]string{
+		return events.APIGatewayProxyResponse{StatusCode: http.StatusOK, Body: "", Headers: map[string]string{
 			"X-Terraform-Get": fmt.Sprintf("git::https://github.com/%s/%s?ref=v%s", params.Namespace, repoName, params.Version),
 		}}, nil
 	}

--- a/src/lambda/api/moduleDownload.go
+++ b/src/lambda/api/moduleDownload.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"fmt"
+
 	"github.com/opentffoundation/registry/internal/config"
 
 	"github.com/aws/aws-lambda-go/events"

--- a/src/lambda/api/moduleVersions.go
+++ b/src/lambda/api/moduleVersions.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"encoding/json"
+
 	"github.com/opentffoundation/registry/internal/config"
 
 	"github.com/aws/aws-lambda-go/events"

--- a/src/lambda/api/moduleVersions.go
+++ b/src/lambda/api/moduleVersions.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"net/http"
 
 	"github.com/opentffoundation/registry/internal/config"
 
@@ -42,7 +43,7 @@ func listModuleVersions(config config.Config) LambdaFunc {
 		// check the repo exists
 		exists, err := github.RepositoryExists(ctx, config.ManagedGithubClient, params.Namespace, repoName)
 		if err != nil {
-			return events.APIGatewayProxyResponse{StatusCode: 500}, err
+			return events.APIGatewayProxyResponse{StatusCode: http.StatusInternalServerError}, err
 		}
 		if !exists {
 			return NotFoundResponse, nil
@@ -51,7 +52,7 @@ func listModuleVersions(config config.Config) LambdaFunc {
 		// fetch all the versions
 		versions, err := modules.GetVersions(ctx, config.RawGithubv4Client, params.Namespace, repoName)
 		if err != nil {
-			return events.APIGatewayProxyResponse{StatusCode: 500}, err
+			return events.APIGatewayProxyResponse{StatusCode: http.StatusInternalServerError}, err
 		}
 
 		response := ListModuleVersionsResponse{
@@ -64,8 +65,8 @@ func listModuleVersions(config config.Config) LambdaFunc {
 
 		resBody, err := json.Marshal(response)
 		if err != nil {
-			return events.APIGatewayProxyResponse{StatusCode: 500}, err
+			return events.APIGatewayProxyResponse{StatusCode: http.StatusInternalServerError}, err
 		}
-		return events.APIGatewayProxyResponse{StatusCode: 200, Body: string(resBody)}, nil
+		return events.APIGatewayProxyResponse{StatusCode: http.StatusOK, Body: string(resBody)}, nil
 	}
 }

--- a/src/lambda/api/providerDownload.go
+++ b/src/lambda/api/providerDownload.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net/http"
 
 	"github.com/opentffoundation/registry/internal/config"
 
@@ -42,7 +43,7 @@ func downloadProviderVersion(config config.Config) LambdaFunc {
 		// check the repo exists
 		exists, err := github.RepositoryExists(ctx, config.ManagedGithubClient, effectiveNamespace, repoName)
 		if err != nil {
-			return events.APIGatewayProxyResponse{StatusCode: 500}, err
+			return events.APIGatewayProxyResponse{StatusCode: http.StatusInternalServerError}, err
 		}
 		if !exists {
 			return NotFoundResponse, nil
@@ -52,13 +53,13 @@ func downloadProviderVersion(config config.Config) LambdaFunc {
 		if err != nil {
 			// log the error too for dev
 			fmt.Printf("error fetching version: %s\n", err)
-			return events.APIGatewayProxyResponse{StatusCode: 500}, err
+			return events.APIGatewayProxyResponse{StatusCode: http.StatusInternalServerError}, err
 		}
 
 		resBody, err := json.Marshal(versionDownloadResponse)
 		if err != nil {
-			return events.APIGatewayProxyResponse{StatusCode: 500}, err
+			return events.APIGatewayProxyResponse{StatusCode: http.StatusInternalServerError}, err
 		}
-		return events.APIGatewayProxyResponse{StatusCode: 200, Body: string(resBody)}, nil
+		return events.APIGatewayProxyResponse{StatusCode: http.StatusOK, Body: string(resBody)}, nil
 	}
 }

--- a/src/lambda/api/providerDownload.go
+++ b/src/lambda/api/providerDownload.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+
 	"github.com/opentffoundation/registry/internal/config"
 
 	"github.com/aws/aws-lambda-go/events"

--- a/src/lambda/api/providerVersions.go
+++ b/src/lambda/api/providerVersions.go
@@ -4,6 +4,9 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
+	"time"
+
 	"github.com/aws/aws-lambda-go/events"
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/lambda"
@@ -11,8 +14,6 @@ import (
 	"github.com/opentffoundation/registry/internal/github"
 	"github.com/opentffoundation/registry/internal/providers"
 	"github.com/opentffoundation/registry/internal/providers/providercache"
-	"os"
-	"time"
 )
 
 const providerCacheAge = 1 * time.Hour

--- a/src/lambda/api/providerVersions.go
+++ b/src/lambda/api/providerVersions.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net/http"
 	"os"
 	"time"
 
@@ -51,7 +52,7 @@ func listProviderVersions(config config.Config) LambdaFunc {
 		if exists, err := github.RepositoryExists(ctx, config.ManagedGithubClient, effectiveNamespace, repoName); !exists {
 			if err != nil {
 				fmt.Printf("Error checking if repo exists: %s\n", err.Error())
-				return events.APIGatewayProxyResponse{StatusCode: 500}, err
+				return events.APIGatewayProxyResponse{StatusCode: http.StatusInternalServerError}, err
 			}
 			fmt.Printf("Repo %s/%s does not exist\n", effectiveNamespace, repoName)
 			// if the repo doesn't exist, there's no point in trying to fetch versions
@@ -88,7 +89,7 @@ func fetchFromGithub(ctx context.Context, config config.Config, namespace, repoN
 
 	versions, err := providers.GetVersions(ctx, config.RawGithubv4Client, namespace, repoName)
 	if err != nil {
-		return events.APIGatewayProxyResponse{StatusCode: 500}, err
+		return events.APIGatewayProxyResponse{StatusCode: http.StatusInternalServerError}, err
 	}
 
 	return versionsResponse(versions)
@@ -115,8 +116,8 @@ func versionsResponse(versions []providers.Version) (events.APIGatewayProxyRespo
 
 	resBody, err := json.Marshal(response)
 	if err != nil {
-		return events.APIGatewayProxyResponse{StatusCode: 500}, err
+		return events.APIGatewayProxyResponse{StatusCode: http.StatusInternalServerError}, err
 	}
 
-	return events.APIGatewayProxyResponse{StatusCode: 200, Body: string(resBody)}, nil
+	return events.APIGatewayProxyResponse{StatusCode: http.StatusOK, Body: string(resBody)}, nil
 }

--- a/src/lambda/api/responses.go
+++ b/src/lambda/api/responses.go
@@ -1,6 +1,10 @@
 package main
 
-import "github.com/aws/aws-lambda-go/events"
+import (
+	"net/http"
+
+	"github.com/aws/aws-lambda-go/events"
+)
 
 //nolint:gochecknoglobals // This should be treated as a constant.
-var NotFoundResponse = events.APIGatewayProxyResponse{StatusCode: 404, Body: `{"errors":["not found"]}`}
+var NotFoundResponse = events.APIGatewayProxyResponse{StatusCode: http.StatusNotFound, Body: `{"errors":["not found"]}`}

--- a/src/lambda/api/responses.go
+++ b/src/lambda/api/responses.go
@@ -2,4 +2,5 @@ package main
 
 import "github.com/aws/aws-lambda-go/events"
 
+//nolint:gochecknoglobals // This should be treated as a constant.
 var NotFoundResponse = events.APIGatewayProxyResponse{StatusCode: 404, Body: `{"errors":["not found"]}`}

--- a/src/lambda/api/router.go
+++ b/src/lambda/api/router.go
@@ -3,9 +3,10 @@ package main
 import (
 	"context"
 	"fmt"
+	"regexp"
+
 	"github.com/aws/aws-xray-sdk-go/xray"
 	"github.com/opentffoundation/registry/internal/config"
-	"regexp"
 
 	"github.com/aws/aws-lambda-go/events"
 )

--- a/src/lambda/api/router.go
+++ b/src/lambda/api/router.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"regexp"
 
 	"github.com/aws/aws-xray-sdk-go/xray"
@@ -50,7 +51,7 @@ func Router(config config.Config) LambdaFunc {
 		ctx, segment := xray.BeginSubsegment(ctx, "registry.handle")
 		handler := getRouteHandler(config, req.Path)
 		if handler == nil {
-			return events.APIGatewayProxyResponse{StatusCode: 404, Body: fmt.Sprintf("No route handler found for path %s", req.Path)}, nil
+			return events.APIGatewayProxyResponse{StatusCode: http.StatusNotFound, Body: fmt.Sprintf("No route handler found for path %s", req.Path)}, nil
 		}
 
 		response, err := handler(ctx, req)

--- a/src/lambda/api/terraformWellKnown.go
+++ b/src/lambda/api/terraformWellKnown.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"net/http"
 
 	"github.com/aws/aws-lambda-go/events"
 	"github.com/opentffoundation/registry/internal/config"
@@ -15,7 +16,7 @@ const wellKnownMetadataResponse = `{
 func terraformWellKnownMetadataHandler(_ config.Config) LambdaFunc {
 	return func(ctx context.Context, req events.APIGatewayProxyRequest) (events.APIGatewayProxyResponse, error) {
 		return events.APIGatewayProxyResponse{
-			StatusCode: 200,
+			StatusCode: http.StatusOK,
 			Body:       wellKnownMetadataResponse,
 		}, nil
 	}

--- a/src/lambda/api/terraformWellKnown.go
+++ b/src/lambda/api/terraformWellKnown.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+
 	"github.com/aws/aws-lambda-go/events"
 	"github.com/opentffoundation/registry/internal/config"
 )

--- a/src/lambda/populate_provider_versions/handler.go
+++ b/src/lambda/populate_provider_versions/handler.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"fmt"
+
 	"github.com/aws/aws-xray-sdk-go/xray"
 	"github.com/opentffoundation/registry/internal/config"
 	"github.com/opentffoundation/registry/internal/github"

--- a/src/lambda/populate_provider_versions/main.go
+++ b/src/lambda/populate_provider_versions/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"fmt"
+
 	"github.com/aws/aws-lambda-go/lambda"
 	"github.com/opentffoundation/registry/internal/config"
 )

--- a/src/lambda/populate_provider_versions/main.go
+++ b/src/lambda/populate_provider_versions/main.go
@@ -9,7 +9,7 @@ import (
 )
 
 func main() {
-	configBuilder := config.NewConfigBuilder()
+	configBuilder := config.NewBuilder()
 	config, err := configBuilder.BuildConfig(context.Background(), "populate_provider_versions.buildconfig")
 	if err != nil {
 		panic(fmt.Errorf("could not build config: %w", err))


### PR DESCRIPTION
This PR introduces golangci-lint into our CI/CD pipeline for automated code quality checks. By incorporating this tool, we can enforce code consistency and catch issues early in the development process.

I've configured a set of linters based on common Go best practices. However, please note that some rules related to logging have been temporarily disabled. This is a deliberate choice to allow for future improvements in our logging mechanism.

Fixes #19 