### PR TITLE
Move to using al2 lambda runtime instead of go

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,12 +34,11 @@ override.tf.json
 terraform.rc
 
 # Build artifacts
-archive.zip
-api.zip
-registry-handler
+populate_provider_versions_bootstrap
+populate_provider_versions_bootstrap.zip
 
-populateproviderversions.zip
-populate-provider-versions
+api_function_bootstrap
+api_bootstrap.zip
 
 # JetBrains folder
 .idea


### PR DESCRIPTION
Fixes #87 

This PR moves us over to the al2 runtime instead of the soon-to-be-deprecated go 1.x

There are some points to note for this PR:

- Binaries running lambda handling in al2 runtime images need to be named `bootstrap` so some extra logic has been added to work around that

- I've addedd the tag `lambda.norpc` to the build to reduce cold start times. This limits the binaries to al2 but should help us overall now that we're on al2. See https://github.com/aws/aws-lambda-go/blob/1f782848d89c02bf802657e77fc6c7d2e50ddec2/lambda/entry.go#L64-L66 for more information.

