### PR TITLE
Reduce cache timings by 5 minutes due to apigateway limitation

### DIFF
--- a/apigw.tf
+++ b/apigw.tf
@@ -298,8 +298,8 @@ resource "aws_api_gateway_method_settings" "download_method_settings" {
   settings {
     metrics_enabled                         = true
     caching_enabled                         = true
-    // 65 minutes to keep it consistent with the provider versions cache TTL
-    cache_ttl_in_seconds                    = (65*60)
+    // 60 minutes to keep it consistent with the provider versions cache TTL
+    cache_ttl_in_seconds                    = (60*60)
     require_authorization_for_cache_control = false
   }
 }
@@ -314,8 +314,8 @@ resource "aws_api_gateway_method_settings" "provider_list_versions_method_settin
   settings {
     metrics_enabled                         = true
     caching_enabled                         = true
-    // 65 minutes, to ensure we're over the (current) one hour limit of backend cache TTL
-    cache_ttl_in_seconds                    = (65*60)
+    // 60 minutes, to ensure we're over the (current) one hour limit of backend cache TTL
+    cache_ttl_in_seconds                    = (60*60)
     require_authorization_for_cache_control = false
   }
 }
@@ -331,8 +331,8 @@ resource "aws_api_gateway_method_settings" "module_download_method_settings" {
     metrics_enabled                         = true
     caching_enabled                         = true
 
-    // 65 minutes to keep it consistent with the provider versions cache TTL
-    cache_ttl_in_seconds                    = (65*60)
+    // 60 minutes to keep it consistent with the provider versions cache TTL
+    cache_ttl_in_seconds                    = (60*60)
     require_authorization_for_cache_control = false
   }
 }
@@ -347,8 +347,8 @@ resource "aws_api_gateway_method_settings" "module_list_versions_method_settings
   settings {
     metrics_enabled                         = true
     caching_enabled                         = true
-    // 65 minutes to keep it consistent with the provider versions cache TTL
-    cache_ttl_in_seconds                    = (65*60)
+    // 60 minutes to keep it consistent with the provider versions cache TTL
+    cache_ttl_in_seconds                    = (60*60)
     require_authorization_for_cache_control = false
   }
 }
@@ -363,8 +363,8 @@ resource "aws_api_gateway_method_settings" "well_known_method_settings" {
   settings {
     metrics_enabled                         = true
     caching_enabled                         = true
-    // 65 minutes to keep it consistent with the provider versions cache TTL
-    cache_ttl_in_seconds                    = (65*60)
+    // 60 minutes to keep it consistent with the provider versions cache TTL
+    cache_ttl_in_seconds                    = (60*60)
     require_authorization_for_cache_control = false
   }
 }

--- a/src/internal/providers/providercache/store.go
+++ b/src/internal/providers/providercache/store.go
@@ -25,7 +25,9 @@ func NewHandler(awsConfig aws.Config, tableName string) *Handler {
 	}
 }
 
-const AllowedAge = 1 * time.Hour
+// AllowedAge is set to 55 minutes here because this ensures that the api gateway caching
+// of 1hr will not expire before the document should is updated when under consistent load.
+const AllowedAge = 1*time.Hour - (5 * time.Minute)
 
 type VersionListingItem struct {
 	Provider    string              `dynamodbav:"provider"`


### PR DESCRIPTION
Right now, api gateway cannot handle cache ttl of longer than one hour. For this reason I've shortened the cache on both sides by 5 minutes.