### PR TITLE
Various fixes around cache timings and ShaSums missing

### DIFF
--- a/apigw.tf
+++ b/apigw.tf
@@ -298,8 +298,8 @@ resource "aws_api_gateway_method_settings" "download_method_settings" {
   settings {
     metrics_enabled                         = true
     caching_enabled                         = true
-    // 65 minutes to keep it consistent with the provider versions cache TTL
-    cache_ttl_in_seconds                    = (65*60)
+    // 60 minutes to keep it consistent with the provider versions cache TTL
+    cache_ttl_in_seconds                    = (60*60)
     require_authorization_for_cache_control = false
   }
 }
@@ -314,8 +314,8 @@ resource "aws_api_gateway_method_settings" "provider_list_versions_method_settin
   settings {
     metrics_enabled                         = true
     caching_enabled                         = true
-    // 65 minutes, to ensure we're over the (current) one hour limit of backend cache TTL
-    cache_ttl_in_seconds                    = (65*60)
+    // 60 minutes, to ensure we're over the (current) one hour limit of backend cache TTL
+    cache_ttl_in_seconds                    = (60*60)
     require_authorization_for_cache_control = false
   }
 }
@@ -331,8 +331,8 @@ resource "aws_api_gateway_method_settings" "module_download_method_settings" {
     metrics_enabled                         = true
     caching_enabled                         = true
 
-    // 65 minutes to keep it consistent with the provider versions cache TTL
-    cache_ttl_in_seconds                    = (65*60)
+    // 60 minutes to keep it consistent with the provider versions cache TTL
+    cache_ttl_in_seconds                    = (60*60)
     require_authorization_for_cache_control = false
   }
 }
@@ -347,8 +347,8 @@ resource "aws_api_gateway_method_settings" "module_list_versions_method_settings
   settings {
     metrics_enabled                         = true
     caching_enabled                         = true
-    // 65 minutes to keep it consistent with the provider versions cache TTL
-    cache_ttl_in_seconds                    = (65*60)
+    // 60 minutes to keep it consistent with the provider versions cache TTL
+    cache_ttl_in_seconds                    = (60*60)
     require_authorization_for_cache_control = false
   }
 }
@@ -363,8 +363,8 @@ resource "aws_api_gateway_method_settings" "well_known_method_settings" {
   settings {
     metrics_enabled                         = true
     caching_enabled                         = true
-    // 65 minutes to keep it consistent with the provider versions cache TTL
-    cache_ttl_in_seconds                    = (65*60)
+    // 60 minutes to keep it consistent with the provider versions cache TTL
+    cache_ttl_in_seconds                    = (60*60)
     require_authorization_for_cache_control = false
   }
 }

--- a/src/internal/github/github.go
+++ b/src/internal/github/github.go
@@ -196,7 +196,7 @@ func DownloadAssetContents(ctx context.Context, downloadURL string) (body io.Rea
 			return fmt.Errorf("failed to create request: %w", reqErr)
 		}
 
-		resp, respErr := httpClient.Do(req)
+		resp, respErr := httpClient.Do(req) //nolint:bodyclose // the caller is responsible for closing the body
 		if respErr != nil {
 			return fmt.Errorf("error downloading asset: %w", respErr)
 		}

--- a/src/internal/github/github.go
+++ b/src/internal/github/github.go
@@ -200,7 +200,6 @@ func DownloadAssetContents(ctx context.Context, downloadURL string) (body io.Rea
 		if respErr != nil {
 			return fmt.Errorf("error downloading asset: %w", respErr)
 		}
-		defer resp.Body.Close()
 
 		if resp.StatusCode != http.StatusOK {
 			return fmt.Errorf("unexpected status code when downloading asset: %d", resp.StatusCode)

--- a/src/internal/providers/utils.go
+++ b/src/internal/providers/utils.go
@@ -25,18 +25,24 @@ func getShaSum(ctx context.Context, downloadURL string, filename string) (shaSum
 			return fmt.Errorf("failed to read asset contents: %w", contentsErr)
 		}
 
-		lines := strings.Split(string(contents), "\n")
-		for _, line := range lines {
-			if strings.HasSuffix(line, filename) {
-				shaSum = strings.Split(line, " ")[0]
-				break
-			}
-		}
+		shaSum = findShaSum(contents, filename, shaSum)
 
 		return nil
 	})
 
-	return
+	return shaSum, err
+}
+
+func findShaSum(contents []byte, filename string, shaSum string) string {
+	lines := strings.Split(string(contents), "\n")
+
+	for _, line := range lines {
+		if strings.HasSuffix(line, filename) {
+			shaSum = strings.Split(line, " ")[0]
+			break
+		}
+	}
+	return shaSum
 }
 
 func getSupportedArchAndOS(assets []github.ReleaseAsset) []platform.Platform {

--- a/src/internal/providers/utils_test.go
+++ b/src/internal/providers/utils_test.go
@@ -1,6 +1,8 @@
 package providers
 
-import "testing"
+import (
+	"testing"
+)
 
 func TestFindShaSum(t *testing.T) {
 	contents := `0002dd4c79453da5bf1bb9c52172a25d042a571f6df131b7c9ced3d1f8f3eb44  terraform-provider-random_3.5.1_linux_386.zip
@@ -21,5 +23,3 @@ eb583d8f03b11f0b6c535375d8ed0d29e5f7f537b5c78943856d2e8ce76482d9  terraform-prov
 		t.Fatal("shaSum not found")
 	}
 }
-
-

--- a/src/internal/providers/utils_test.go
+++ b/src/internal/providers/utils_test.go
@@ -1,0 +1,25 @@
+package providers
+
+import "testing"
+
+func TestFindShaSum(t *testing.T) {
+	contents := `0002dd4c79453da5bf1bb9c52172a25d042a571f6df131b7c9ced3d1f8f3eb44  terraform-provider-random_3.5.1_linux_386.zip
+49b0f8c2bd5632799aa6113e0e46acaa7d008f927665a41a1f8e8559fe6d8165  terraform-provider-random_3.5.1_darwin_amd64.zip
+56df70fca236caa06d0e636c41ab71dd1ced05375f4ddcb905b0ed2105737048  terraform-provider-random_3.5.1_windows_386.zip
+58e4de40540c86b9e2e2595dac1318ba057718961a467fa9727866f747693eb2  terraform-provider-random_3.5.1_windows_arm64.zip
+5992f11c738812ccd7476d4c607cb8b76dea5aa612be491150c89957ec395ddd  terraform-provider-random_3.5.1_darwin_arm64.zip
+7ff4f0b7707b51737f684e96d85a47f0dd8be0f72a3c27b0798755d3faad15e2  terraform-provider-random_3.5.1_linux_arm.zip
+8e4b0972e216c9773ab525accfa36eb27c44c751b06b125ecc53f4226c91cea8  terraform-provider-random_3.5.1_linux_arm64.zip
+d8956cc5abcd5d1173b6cc25d5d8ed2c5cc456edab2fddb774a17d45e84820cb  terraform-provider-random_3.5.1_linux_amd64.zip
+df7f9eb93a832e66bc20cc41c57d38954f87671ec60be09fa866273adb8d9353  terraform-provider-random_3.5.1_windows_amd64.zip
+eb583d8f03b11f0b6c535375d8ed0d29e5f7f537b5c78943856d2e8ce76482d9  terraform-provider-random_3.5.1_windows_arm.zip
+`
+
+	filename := "terraform-provider-random_3.5.1_linux_amd64.zip"
+	shaSum := findShaSum([]byte(contents), filename, "")
+	if shaSum != "d8956cc5abcd5d1173b6cc25d5d8ed2c5cc456edab2fddb774a17d45e84820cb" {
+		t.Fatal("shaSum not found")
+	}
+}
+
+


### PR DESCRIPTION
This PR fixes 2 things.

1. It reduces down the time of caching by 5 minutes. This is because API Gateway cannot handle cache ttl over 1 hour.

2. It fixes an issue where we were closing the body of the sha sum file too early, resulting in no shasum being returned for providers.

3. Introduces a simple test for finding the shasum, just incase!