### PR TITLE
Resize the provider cache to be 55 minutes long 

### DIFF
--- a/src/internal/providers/providercache/store.go
+++ b/src/internal/providers/providercache/store.go
@@ -25,7 +25,7 @@ func NewHandler(awsConfig aws.Config, tableName string) *Handler {
 	}
 }
 
-const AllowedAge = 1 * time.Hour
+const AllowedAge = (1 * time.Hour) - (5 * time.Minute) //nolint:gomnd // 55 minutes
 
 type VersionListingItem struct {
 	Provider    string              `dynamodbav:"provider"`


### PR DESCRIPTION
This ensures that once the hour long api gateway cache is completed and we hit again, we should always fetch a new set of versions.