### PR TITLE
Fix issue where null versions were being stored in dynamodb erroneously

### DIFF
--- a/src/lambda/populate_provider_versions/handler.go
+++ b/src/lambda/populate_provider_versions/handler.go
@@ -87,6 +87,10 @@ func HandleRequest(config *config.Config) LambdaFunc {
 			return "", err
 		}
 
+		if len(versions) == 0 {
+			return "", fmt.Errorf("no versions found")
+		}
+
 		key := fmt.Sprintf("%s/%s", e.Namespace, e.Type)
 
 		err = config.ProviderVersionCache.Store(ctx, key, versions)


### PR DESCRIPTION
#84 introduced a small bug in that we were returning `nil` from the xray capture, and not filtering if we fetched versions or not outside.

This resolves this by ensuring that we don't store a null list of versions

This PR also refactors some of handler.go due to it getting a bit too complex.