### PR TITLE
Introduce a 'since' arguement to provider version fetching to only fetch latest releases

### DIFF
--- a/src/internal/modules/versions.go
+++ b/src/internal/modules/versions.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/aws/aws-xray-sdk-go/xray"
 	"github.com/shurcooL/githubv4"
@@ -13,14 +14,14 @@ import (
 )
 
 // GetVersions fetches a list of versions for a GitHub repository identified by its namespace and name.
-func GetVersions(ctx context.Context, ghClient *githubv4.Client, namespace string, name string) (versions []Version, err error) {
+func GetVersions(ctx context.Context, ghClient *githubv4.Client, namespace string, name string, since *time.Time) (versions []Version, err error) {
 	err = xray.Capture(ctx, "module.versions", func(tracedCtx context.Context) error {
 		xray.AddAnnotation(tracedCtx, "namespace", namespace)
 		xray.AddAnnotation(tracedCtx, "name", name)
 
 		slog.Info("Fetching releases")
 
-		releases, fetchErr := github.FetchReleases(tracedCtx, ghClient, namespace, name)
+		releases, fetchErr := github.FetchReleases(tracedCtx, ghClient, namespace, name, since)
 		if err != nil {
 			return fmt.Errorf("failed to fetch releases: %w", fetchErr)
 		}

--- a/src/lambda/api/moduleVersions.go
+++ b/src/lambda/api/moduleVersions.go
@@ -60,8 +60,11 @@ func listModuleVersions(config config.Config) LambdaFunc {
 			return NotFoundResponse, nil
 		}
 
+		// TODO: Implement ddb caching similar to provider versions, but for modules
+		// this will also allow us to populate the `since` parameter in the module.GetVersions call below
+
 		// fetch all the versions
-		versions, err := modules.GetVersions(ctx, config.RawGithubv4Client, params.Namespace, repoName)
+		versions, err := modules.GetVersions(ctx, config.RawGithubv4Client, params.Namespace, repoName, nil)
 		if err != nil {
 			return events.APIGatewayProxyResponse{StatusCode: http.StatusInternalServerError}, err
 		}

--- a/src/lambda/api/providerVersions.go
+++ b/src/lambda/api/providerVersions.go
@@ -107,7 +107,7 @@ func listVersionsFromRepository(ctx context.Context, config config.Config, effec
 	}
 
 	slog.Info("Fetching versions from github\n")
-	versionList, err := providers.GetVersions(ctx, config.RawGithubv4Client, effectiveNamespace, repoName)
+	versionList, err := providers.GetVersions(ctx, config.RawGithubv4Client, effectiveNamespace, repoName, nil)
 	return versionList.ToVersions(), exists, err
 }
 

--- a/src/lambda/populate_provider_versions/handler.go
+++ b/src/lambda/populate_provider_versions/handler.go
@@ -79,10 +79,10 @@ func HandleRequest(config *config.Config) LambdaFunc {
 				return err
 			}
 
+			// if we have a document, we should combine the fetched versions with the existing versions
+			// this is so that we don't lose any versions that were added since the last time we fetched
+			// but also so we don't add duplicates
 			if since != nil && document != nil {
-				// if we have a document, we should combine the fetched versions with the existing versions
-				// this is so that we don't lose any versions that were added since the last time we fetched
-				// but also so we don't add duplicates
 				fetchedVersions = append(document.Versions, fetchedVersions...)
 				slog.Info("Combined versions", "versions", len(fetchedVersions))
 			}

--- a/src/lambda/populate_provider_versions/handler.go
+++ b/src/lambda/populate_provider_versions/handler.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"time"
 
 	"github.com/aws/aws-xray-sdk-go/xray"
 	"github.com/opentofu/registry/internal/config"
@@ -55,6 +56,8 @@ func HandleRequest(config *config.Config) LambdaFunc {
 				return fmt.Errorf("invalid event: %w", err)
 			}
 
+			var since *time.Time
+
 			// check if the document exists in dynamodb, if it does, and it's newer than the allowed max age,
 			// we should treat it as a noop and just return
 			document, err := config.ProviderVersionCache.GetItem(tracedCtx, fmt.Sprintf("%s/%s", e.Namespace, e.Type))
@@ -69,9 +72,17 @@ func HandleRequest(config *config.Config) LambdaFunc {
 				}
 			}
 
-			fetchedVersions, err := fetchFromGithub(tracedCtx, e, config)
+			fetchedVersions, err := fetchFromGithub(tracedCtx, e, config, since)
 			if err != nil {
 				return err
+			}
+
+			if since != nil {
+				// if we have a document, we should combine the fetched versions with the existing versions
+				// this is so that we don't lose any versions that were added since the last time we fetched
+				// but also so we don't add duplicates
+				fetchedVersions = append(document.Versions, fetchedVersions...)
+				slog.Info("Combined versions", "versions", len(fetchedVersions))
 			}
 
 			versions = fetchedVersions
@@ -95,7 +106,7 @@ func HandleRequest(config *config.Config) LambdaFunc {
 func storeVersions(ctx context.Context, e PopulateProviderVersionsEvent, versions types.VersionList, config *config.Config) error {
 	if len(versions) == 0 {
 		slog.Error("No versions found, skipping storage")
-		return fmt.Errorf("no versions found")
+		return nil
 	}
 
 	key := fmt.Sprintf("%s/%s", e.Namespace, e.Type)
@@ -107,22 +118,29 @@ func storeVersions(ctx context.Context, e PopulateProviderVersionsEvent, version
 	return nil
 }
 
-func fetchFromGithub(ctx context.Context, e PopulateProviderVersionsEvent, config *config.Config) (types.VersionList, error) {
+func fetchFromGithub(ctx context.Context, e PopulateProviderVersionsEvent, config *config.Config, since *time.Time) (types.VersionList, error) {
 	// Construct the repo name.
 	repoName := providers.GetRepoName(e.Type)
 
-	// check the repo exists
-	exists, err := github.RepositoryExists(ctx, config.ManagedGithubClient, e.Namespace, repoName)
-	if err != nil {
-		return nil, fmt.Errorf("failed to check if repo exists: %w", err)
-	}
-	if !exists {
-		return nil, fmt.Errorf("repo %s/%s does not exist", e.Namespace, repoName)
+	// if we've been provided with a "since" we don't have to check if the repo exists
+	// we can assume that it does because we've already fetched versions from it before
+
+	if since == nil {
+		// check the repo exists
+		exists, err := github.RepositoryExists(ctx, config.ManagedGithubClient, e.Namespace, repoName)
+		if err != nil {
+			return nil, fmt.Errorf("failed to check if repo exists: %w", err)
+		}
+		if !exists {
+			return nil, fmt.Errorf("repo %s/%s does not exist", e.Namespace, repoName)
+		}
+	} else {
+		slog.Info("Skipping repo existence check because we already have a document in dynamodb")
 	}
 
 	slog.Info("Fetching versions")
 
-	v, err := providers.GetVersions(ctx, config.RawGithubv4Client, e.Namespace, repoName)
+	v, err := providers.GetVersions(ctx, config.RawGithubv4Client, e.Namespace, repoName, since)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get versions: %w", err)
 	}

--- a/src/lambda/populate_provider_versions/handler.go
+++ b/src/lambda/populate_provider_versions/handler.go
@@ -70,6 +70,8 @@ func HandleRequest(config *config.Config) LambdaFunc {
 					slog.Info("Document is up to date, not updating")
 					return nil
 				}
+				slog.Info("Document is stale, fetching versions", "last_updated", document.LastUpdated)
+				since = &document.LastUpdated
 			}
 
 			fetchedVersions, err := fetchFromGithub(tracedCtx, e, config, since)
@@ -77,7 +79,7 @@ func HandleRequest(config *config.Config) LambdaFunc {
 				return err
 			}
 
-			if since != nil {
+			if since != nil && document != nil {
 				// if we have a document, we should combine the fetched versions with the existing versions
 				// this is so that we don't lose any versions that were added since the last time we fetched
 				// but also so we don't add duplicates


### PR DESCRIPTION
Related to #97 

This is an attempt at a new approach for populating version releases. 

This PR does 2 things.

1. Only fetch new github releases if we already have a document in dynamodb. 

2. For provider downloads (not listing). We now check if we know about the document in dynamodb first instead of always hitting github to check if the repo exists.

Both of these items should drastically reduce the amount of github API calls that occur. 

This PR Also mitigates any issues that occur when repeatedly fetching information about old releases.