### PR TITLE
Update lambda timeout for provider version fetching to 10 minutes

### DIFF
--- a/lambda.tf
+++ b/lambda.tf
@@ -80,7 +80,7 @@ resource "aws_lambda_function" "populate_provider_versions_function" {
   role          = aws_iam_role.lambda.arn
   handler       = "populate-provider-versions"
   memory_size   = 128
-  timeout       = 60
+  timeout       = 10 * 60
 
   filename         = data.archive_file.populate_provider_versions_archive.output_path
   source_code_hash = data.archive_file.api_function_archive.output_base64sha256


### PR DESCRIPTION
This ups the timeout because 1 minute was not enough for some providers that had a large amount of versions. 