### PR TITLE
Fixed issue where a provider release without signatures would cause a nilptr panic

### DIFF
--- a/src/internal/providers/versions.go
+++ b/src/internal/providers/versions.go
@@ -135,6 +135,13 @@ func getVersionFromGithubRelease(ctx context.Context, r github.GHRelease, versio
 	shaSumsURL := github.FindAssetBySuffix(assets, "_SHA256SUMS")
 	shaSumsSignatureURL := github.FindAssetBySuffix(assets, "_SHA256SUMS.sig")
 
+	if shaSumsSignatureURL == nil {
+		// make an empty one
+		shaSumsSignatureURL = &github.ReleaseAsset{
+			DownloadURL: "",
+		}
+	}
+
 	// for each of the supported platforms, we need to find the appropriate assets
 	// and add them to the version result
 	for _, platform := range platforms {


### PR DESCRIPTION
Now if we cannot find the shasums signature url, we will just return an empty DownloadURL for it.