### PR TITLE
Correctly return false when we are unable to find version details for a specific arch+os

### DIFF
--- a/src/internal/providers/types/types.go
+++ b/src/internal/providers/types/types.go
@@ -69,7 +69,11 @@ func (l VersionList) ToVersions() []Version {
 func (i *CacheItem) GetVersionDetails(version string, os string, arch string) (*VersionDetails, bool) {
 	for _, v := range i.Versions {
 		if v.Version == version {
-			return v.GetVersionDetails(os, arch), true
+			versionDetails := v.GetVersionDetails(os, arch)
+			if versionDetails == nil {
+				return nil, false
+			}
+			return versionDetails, true
 		}
 	}
 	return nil, false


### PR DESCRIPTION
Because GetVersionDetails on the *CacheVersion type returns nil if it cannot find the object, we should check for nil versionDetails here. 