### PR TITLE
Don't throw 502s if the resource isn't found

### DIFF
--- a/src/internal/providers/errors.go
+++ b/src/internal/providers/errors.go
@@ -1,0 +1,35 @@
+package providers
+
+import "fmt"
+
+type FetchErrorCode int
+
+const (
+	ErrCodeReleaseNotFound       FetchErrorCode = 1
+	ErrCodeAssetNotFound         FetchErrorCode = 2
+	ErrCodeSHASumsNotFound       FetchErrorCode = 3
+	ErrCodeManifestNotFound      FetchErrorCode = 4
+	ErrCodeCouldNotGetPublicKeys FetchErrorCode = 5
+)
+
+type FetchError struct {
+	Inner   error
+	Message string
+	Code    FetchErrorCode
+}
+
+func (p *FetchError) Error() string {
+	return fmt.Sprintf("%d, %s", p.Code, p.Message)
+}
+
+func (p *FetchError) Unwrap() error {
+	return p.Inner
+}
+
+func newFetchError(message string, code FetchErrorCode, err error) error {
+	return &FetchError{
+		Message: message,
+		Code:    code,
+		Inner:   err,
+	}
+}

--- a/src/internal/providers/versions.go
+++ b/src/internal/providers/versions.go
@@ -264,7 +264,6 @@ func GetVersion(ctx context.Context, ghClient *githubv4.Client, namespace string
 		manifest, manifestErr := findAndParseManifest(tracedCtx, release.ReleaseAssets.Nodes)
 		if manifestErr != nil {
 			return newFetchError("failed to find and parse manifest", ErrCodeManifestNotFound, manifestErr)
-			return fmt.Errorf("failed to find and parse manifest: %w", manifestErr)
 		}
 
 		if manifest != nil {

--- a/src/internal/providers/versions.go
+++ b/src/internal/providers/versions.go
@@ -251,7 +251,7 @@ func GetVersion(ctx context.Context, ghClient *githubv4.Client, namespace string
 		}
 
 		if release == nil {
-			return fmt.Errorf("release not found")
+			return newFetchError("failed to find release", ErrCodeReleaseNotFound, nil)
 		}
 
 		// Initialize the VersionDetails struct.
@@ -263,6 +263,7 @@ func GetVersion(ctx context.Context, ghClient *githubv4.Client, namespace string
 		// Find and parse the manifest from the release assets.
 		manifest, manifestErr := findAndParseManifest(tracedCtx, release.ReleaseAssets.Nodes)
 		if manifestErr != nil {
+			return newFetchError("failed to find and parse manifest", ErrCodeManifestNotFound, manifestErr)
 			return fmt.Errorf("failed to find and parse manifest: %w", manifestErr)
 		}
 
@@ -275,7 +276,7 @@ func GetVersion(ctx context.Context, ghClient *githubv4.Client, namespace string
 		// Identify the appropriate asset for download based on OS and architecture.
 		assetToDownload := github.FindAssetBySuffix(release.ReleaseAssets.Nodes, fmt.Sprintf("_%s_%s.zip", os, arch))
 		if assetToDownload == nil {
-			return fmt.Errorf("could not find asset to download")
+			return newFetchError("failed to find asset to download", ErrCodeAssetNotFound, nil)
 		}
 		versionDetails.Filename = assetToDownload.Name
 		versionDetails.DownloadURL = assetToDownload.DownloadURL
@@ -286,7 +287,7 @@ func GetVersion(ctx context.Context, ghClient *githubv4.Client, namespace string
 
 		if shaSumsAsset == nil || shasumsSigAsset == nil {
 			slog.Error("Could not find shasums or its signature asset")
-			return fmt.Errorf("could not find shasums or its signature asset")
+			return newFetchError("failed to find shasums or its signature asset", ErrCodeSHASumsNotFound, nil)
 		}
 
 		versionDetails.SHASumsURL = shaSumsAsset.DownloadURL
@@ -296,14 +297,14 @@ func GetVersion(ctx context.Context, ghClient *githubv4.Client, namespace string
 		shaSum, shaSumErr := getShaSum(tracedCtx, shaSumsAsset.DownloadURL, versionDetails.Filename)
 		if shaSumErr != nil {
 			slog.Error("Could not get shasum", "error", shaSumErr)
-			return fmt.Errorf("failed to get shasum: %w", shaSumErr)
+			return newFetchError("failed to get shasum: %w", ErrCodeSHASumsNotFound, shaSumErr)
 		}
 		versionDetails.SHASum = shaSum
 
 		publicKeys, keysErr := KeysForNamespace(namespace)
 		if keysErr != nil {
 			slog.Error("Could not get public keys", "error", keysErr)
-			return fmt.Errorf("failed to get public keys: %w", keysErr)
+			return newFetchError("failed to get public keys", ErrCodeCouldNotGetPublicKeys, keysErr)
 		}
 
 		versionDetails.SigningKeys = types.SigningKeys{

--- a/src/lambda/api/providerDownload.go
+++ b/src/lambda/api/providerDownload.go
@@ -84,9 +84,9 @@ func downloadProviderVersion(config config.Config) LambdaFunc {
 func fetchVersionFromGithub(ctx context.Context, config config.Config, effectiveNamespace string, repoName string, params DownloadHandlerPathParams) (events.APIGatewayProxyResponse, error) {
 	versionDownloadResponse, err := providers.GetVersion(ctx, config.RawGithubv4Client, effectiveNamespace, repoName, params.Version, params.OS, params.Architecture)
 	if err != nil {
-		var fetchErr providers.FetchError
+		var fetchErr *providers.FetchError
 		// if it's a providers.FetchError
-		if errors.As(err, &providers.FetchError{}) {
+		if errors.As(err, &fetchErr) {
 			if fetchErr.Code == providers.ErrCodeReleaseNotFound {
 				slog.Info("Release not found in repo")
 				return NotFoundResponse, nil

--- a/src/lambda/api/providerDownload.go
+++ b/src/lambda/api/providerDownload.go
@@ -87,8 +87,12 @@ func fetchVersionFromGithub(ctx context.Context, config config.Config, effective
 		var fetchErr *providers.FetchError
 		// if it's a providers.FetchError
 		if errors.As(err, &fetchErr) {
-			if fetchErr.Code == providers.ErrCodeReleaseNotFound || fetchErr.Code == providers.ErrCodeAssetNotFound {
+			if fetchErr.Code == providers.ErrCodeReleaseNotFound {
 				slog.Info("Release not found in repo")
+				return NotFoundResponse, nil
+			}
+			if fetchErr.Code == providers.ErrCodeAssetNotFound {
+				slog.Info("Asset for download not found in release")
 				return NotFoundResponse, nil
 			}
 			return events.APIGatewayProxyResponse{StatusCode: http.StatusInternalServerError}, err

--- a/src/lambda/api/providerDownload.go
+++ b/src/lambda/api/providerDownload.go
@@ -87,7 +87,7 @@ func fetchVersionFromGithub(ctx context.Context, config config.Config, effective
 		var fetchErr *providers.FetchError
 		// if it's a providers.FetchError
 		if errors.As(err, &fetchErr) {
-			if fetchErr.Code == providers.ErrCodeReleaseNotFound {
+			if fetchErr.Code == providers.ErrCodeReleaseNotFound || fetchErr.Code == providers.ErrCodeAssetNotFound {
 				slog.Info("Release not found in repo")
 				return NotFoundResponse, nil
 			}


### PR DESCRIPTION
Fixes #102 

As an expansion of #104 I've raised this PR

(The old PR needed a lot of rebasing doing, and the author was unable to work on this until wednesday)

I've taken the same concept but instead of using http codes I've just defined some codes as constants that we can use.