### PR TITLE
Support both `X.X.X` and `vX.X.X` tags for modules

### DIFF
--- a/src/lambda/api/moduleDownload.go
+++ b/src/lambda/api/moduleDownload.go
@@ -35,6 +35,7 @@ func downloadModuleVersion(config config.Config) LambdaFunc {
 	return func(ctx context.Context, req events.APIGatewayProxyRequest) (events.APIGatewayProxyResponse, error) {
 		params := getDownloadModuleHandlerPathParams(req)
 		params.AnnotateLogger()
+		effectiveNamespace := config.EffectiveProviderNamespace(params.Namespace)
 		repoName := modules.GetRepoName(params.System, params.Name)
 
 		// check if the repo exists
@@ -47,8 +48,13 @@ func downloadModuleVersion(config config.Config) LambdaFunc {
 			return NotFoundResponse, nil
 		}
 
+		releaseTag, err := getReleaseTag(ctx, config, effectiveNamespace, repoName, params.Version)
+		if err != nil {
+			return events.APIGatewayProxyResponse{StatusCode: http.StatusInternalServerError}, err
+		}
+
 		return events.APIGatewayProxyResponse{StatusCode: http.StatusOK, Body: "", Headers: map[string]string{
-			"X-Terraform-Get": fmt.Sprintf("git::https://github.com/%s/%s?ref=v%s", params.Namespace, repoName, params.Version),
+			"X-Terraform-Get": fmt.Sprintf("git::https://github.com/%s/%s?ref=%s", params.Namespace, repoName, releaseTag),
 		}}, nil
 	}
 }
@@ -60,4 +66,22 @@ func getDownloadModuleHandlerPathParams(req events.APIGatewayProxyRequest) Downl
 		System:    req.PathParameters["system"],
 		Version:   req.PathParameters["version"],
 	}
+}
+
+func getReleaseTag(ctx context.Context, config config.Config, namespace string, repoName string, version string) (string, error) {
+	// TODO: Create a modulecache, similar to the providercache, and use it here to avoid unnecessary API calls to GitHub
+	// First we check if a tag with "v" prefix exists in GitHub
+	versionWithPrefix := fmt.Sprintf("v%s", version)
+	release, err := github.FindRelease(ctx, config.RawGithubv4Client, namespace, repoName, versionWithPrefix)
+	if err != nil {
+		return "", err
+	}
+
+	// If the release exists, then the tag does have the "v" prefix
+	// If it does not, then we assume the tag exists without the "v" prefix
+	if release != nil {
+		return versionWithPrefix, nil
+	}
+
+	return version, nil
 }


### PR DESCRIPTION
Fixes https://github.com/opentofu/registry/issues/121

Validate that tag `vX.X.X` exists before returning the github redirect URL. If it doesn't, then assume the tag is in format `X.X.X`
This part could benefit later on from caching in DDB, to avoid unnecessary API calls to GH