### PR TITLE
Fix: Downloading some modules result in `error: pathspec`

### DIFF
--- a/src/lambda/api/moduleDownload.go
+++ b/src/lambda/api/moduleDownload.go
@@ -70,8 +70,7 @@ func getDownloadModuleHandlerPathParams(req events.APIGatewayProxyRequest) Downl
 func getReleaseTag(ctx context.Context, config config.Config, namespace string, repoName string, version string) (string, error) {
 	// TODO: Create a modulecache, similar to the providercache, and use it here to avoid unnecessary API calls to GitHub
 	// First we check if a tag with "v" prefix exists in GitHub
-	versionWithPrefix := fmt.Sprintf("v%s", version)
-	release, err := github.FindRelease(ctx, config.RawGithubv4Client, namespace, repoName, versionWithPrefix)
+	release, err := github.FindRelease(ctx, config.RawGithubv4Client, namespace, repoName, version)
 	if err != nil {
 		return "", err
 	}
@@ -79,7 +78,7 @@ func getReleaseTag(ctx context.Context, config config.Config, namespace string, 
 	// If the release exists, then the tag does have the "v" prefix
 	// If it does not, then we assume the tag exists without the "v" prefix
 	if release != nil {
-		return versionWithPrefix, nil
+		return fmt.Sprintf("v%s", version), nil
 	}
 
 	return version, nil


### PR DESCRIPTION
My [previous PR](https://github.com/opentofu/registry/pull/128) did not cut it, to fix [the issue](https://github.com/opentofu/registry/issues/127)

After that, attempting to use the `hashicorpt/vault/aws` modules resulted in:
`Could not download module "root" (<main configuration>:1) source code from "git::https://github.com/hashicorp/terraform-aws-vault?ref=0.17.0": error downloading 'https://github.com/hashicorp/terraform-aws-vault?ref=0.17.0': /usr/bin/git exited with 1: error: pathspec│ '0.17.0' did not match any file(s) known to git`

Reason being that `fetchRelease` assumes that the `version` is without `v`, and that the tag it searches for does have a `v`.