### PR TITLE
Improve error handling around provider version fetching.

### DIFF
--- a/src/internal/providers/versions.go
+++ b/src/internal/providers/versions.go
@@ -82,8 +82,13 @@ func GetVersions(ctx context.Context, ghClient *githubv4.Client, namespace strin
 		return nil
 	})
 
+	if err != nil {
+		slog.Info("Failed to find versions", "error", err)
+		return nil, err
+	}
+
 	slog.Info("Successfully found versions", "versions", len(versions))
-	return versions, err
+	return versions, nil
 }
 
 // getVersionFromGithubRelease fetches and returns detailed information about a specific version of a provider hosted on GitHub.


### PR DESCRIPTION
This PR does 2 things primarily

1. moves the creation of the result.Version in GetVersions so that we don't accidentally return a half created version

2. Changes the logic of fetching versions to ensure that we error if we fail to fetch any of the version information. This ensures that our information is always correct and not partial