### PR TITLE
Add retention time for cloudwatch logs

### DIFF
--- a/apigw.tf
+++ b/apigw.tf
@@ -1,6 +1,15 @@
+locals {
+  stage_name = "${replace(var.domain_name, ".", "-")}-opentofu-registry"
+}
+
 resource "aws_api_gateway_rest_api" "api" {
   name        = "${var.domain_name}-opentofu-registry"
   description = "API Gateway for the OpenTofu Registry"
+}
+
+resource "aws_cloudwatch_log_group" "api_gateway_execution_logs" {
+  name = "API-Gateway-Execution-Logs_${aws_api_gateway_rest_api.api.id}/${local.stage_name}"
+  retention_in_days = 7
 }
 
 resource "aws_api_gateway_resource" "github" {
@@ -373,9 +382,10 @@ resource "aws_cloudwatch_log_group" "apigw_log_group" {
 }
 
 resource "aws_api_gateway_stage" "stage" {
+  depends_on = [aws_cloudwatch_log_group.apigw_log_group]
   deployment_id = aws_api_gateway_deployment.deployment.id
   rest_api_id   = aws_api_gateway_rest_api.api.id
-  stage_name    = "${replace(var.domain_name, ".", "-")}-opentofu-registry"
+  stage_name    = local.stage_name
 
   xray_tracing_enabled = true
 


### PR DESCRIPTION
Fix #107 
Got rollback by #136 (as a cycle issue)

use `aws_cloudwatch_log_group` resource to manage it 
As docs say
- [aws_api_gateway_stage | Resources | hashicorp/aws | Terraform | Terraform Registry](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/api_gateway_stage) 
- [aws_lambda_function | Resources | hashicorp/aws | Terraform | Terraform Registry](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_function) 

Fixed the issue by exporting the function name to a `local` and use it
`terraform plan` doesn't say about any cycle